### PR TITLE
Auto fixture v4

### DIFF
--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/AutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/AutoMockDataAttributeTests.cs
@@ -4,13 +4,13 @@
     using System.Collections.Generic;
     using System.Reflection;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoMoq;
+    using global::AutoFixture.Xunit2;
     using Moq;
     using Objectivity.AutoFixture.XUnit2.AutoMoq.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoMoq;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
     using Xunit.Sdk;
 

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
@@ -4,13 +4,13 @@
     using System.Collections.Generic;
     using System.Reflection;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoMoq;
+    using global::AutoFixture.Xunit2;
     using Moq;
     using Objectivity.AutoFixture.XUnit2.AutoMoq.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoMoq;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
     using Xunit.Sdk;
 

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
@@ -4,12 +4,12 @@
     using System.Collections.Generic;
     using System.Linq;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoMoq;
+    using global::AutoFixture.Xunit2;
     using Moq;
     using Objectivity.AutoFixture.XUnit2.AutoMoq.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoMoq;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("MemberAutoMockDataAttribute")]

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
@@ -56,6 +56,15 @@
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoFixture, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.4.0.0\lib\net452\AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.AutoMoq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.AutoMoq.4.0.0\lib\net452\AutoFixture.AutoMoq.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.Xunit2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.Xunit2.4.0.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
@@ -68,16 +77,8 @@
     <Reference Include="Moq, Version=4.7.142.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.7.142\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.51.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.AutoMoq.3.51.0\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.Xunit2.3.51.0\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/packages.config
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.51.0" targetFramework="net461" />
-  <package id="AutoFixture.AutoMoq" version="3.51.0" targetFramework="net461" />
-  <package id="AutoFixture.Xunit2" version="3.51.0" targetFramework="net461" />
+  <package id="AutoFixture" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.AutoMoq" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="4.0.0" targetFramework="net461" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="FluentAssertions" version="4.19.4" targetFramework="net461" />
   <package id="Moq" version="4.7.142" targetFramework="net461" />

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Attributes/AutoMockDataAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Attributes/AutoMockDataAttribute.cs
@@ -1,11 +1,11 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.AutoMoq.Attributes
 {
     using System;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoMoq;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoMoq;
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public sealed class AutoMockDataAttribute : AutoDataBaseAttribute

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Attributes/InlineAutoMockDataAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Attributes/InlineAutoMockDataAttribute.cs
@@ -1,11 +1,11 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.AutoMoq.Attributes
 {
     using System;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoMoq;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoMoq;
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class InlineAutoMockDataAttribute : InlineAutoDataBaseAttribute

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Attributes/MemberAutoMockDataAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Attributes/MemberAutoMockDataAttribute.cs
@@ -1,11 +1,11 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.AutoMoq.Attributes
 {
     using System;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoMoq;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoMoq;
     using Xunit.Sdk;
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Objectivity.AutoFixture.XUnit2.AutoMoq.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Objectivity.AutoFixture.XUnit2.AutoMoq.csproj
@@ -55,6 +55,15 @@
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoFixture, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.4.0.0\lib\net452\AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.AutoMoq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.AutoMoq.4.0.0\lib\net452\AutoFixture.AutoMoq.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.Xunit2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.Xunit2.4.0.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
@@ -64,16 +73,8 @@
     <Reference Include="Moq, Version=4.7.142.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.7.142\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.51.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.AutoMoq.3.51.0\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.Xunit2.3.51.0\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq/packages.config
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.51.0" targetFramework="net452" />
-  <package id="AutoFixture.AutoMoq" version="3.51.0" targetFramework="net452" />
-  <package id="AutoFixture.Xunit2" version="3.51.0" targetFramework="net452" />
+  <package id="AutoFixture" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.AutoMoq" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="4.0.0" targetFramework="net461" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="JetBrains.Annotations" version="11.1.0" targetFramework="net461" />
   <package id="Moq" version="4.7.142" targetFramework="net461" />

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/AutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/AutoMockDataAttributeTests.cs
@@ -4,13 +4,13 @@
     using System.Collections.Generic;
     using System.Reflection;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoNSubstitute;
+    using global::AutoFixture.Xunit2;
     using NSubstitute;
     using Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoNSubstitute;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
     using Xunit.Sdk;
 

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/InlineAutoMockDataAttributeTests.cs
@@ -4,13 +4,13 @@
     using System.Collections.Generic;
     using System.Reflection;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoNSubstitute;
+    using global::AutoFixture.Xunit2;
     using NSubstitute;
     using Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoNSubstitute;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
     using Xunit.Sdk;
 

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Attributes/MemberAutoMockDataAttributeTests.cs
@@ -4,12 +4,12 @@
     using System.Collections.Generic;
     using System.Linq;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoNSubstitute;
+    using global::AutoFixture.Xunit2;
     using NSubstitute;
     using Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoNSubstitute;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("MemberAutoMockDataAttribute")]

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
@@ -56,6 +56,15 @@
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoFixture, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.4.0.0\lib\net452\AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.AutoNSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.AutoNSubstitute.4.0.0\lib\net452\AutoFixture.AutoNSubstitute.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.Xunit2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.Xunit2.4.0.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
@@ -69,16 +78,8 @@
     <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.51.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoNSubstitute, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.AutoNSubstitute.3.51.0\lib\net40\Ploeh.AutoFixture.AutoNSubstitute.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.Xunit2.3.51.0\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/packages.config
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.51.0" targetFramework="net461" />
-  <package id="AutoFixture.AutoNSubstitute" version="3.51.0" targetFramework="net461" />
-  <package id="AutoFixture.Xunit2" version="3.51.0" targetFramework="net461" />
+  <package id="AutoFixture" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.AutoNSubstitute" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="4.0.0" targetFramework="net461" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="FluentAssertions" version="4.19.4" targetFramework="net461" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net461" />

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Attributes/AutoMockDataAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Attributes/AutoMockDataAttribute.cs
@@ -1,11 +1,11 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Attributes
 {
     using System;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoNSubstitute;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoNSubstitute;
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public sealed class AutoMockDataAttribute : AutoDataBaseAttribute

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Attributes/InlineAutoMockDataAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Attributes/InlineAutoMockDataAttribute.cs
@@ -1,11 +1,11 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Attributes
 {
     using System;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoNSubstitute;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoNSubstitute;
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public sealed class InlineAutoMockDataAttribute : InlineAutoDataBaseAttribute

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Attributes/MemberAutoMockDataAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Attributes/MemberAutoMockDataAttribute.cs
@@ -1,11 +1,11 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Attributes
 {
     using System;
+    using global::AutoFixture;
+    using global::AutoFixture.AutoNSubstitute;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.AutoNSubstitute;
     using Xunit.Sdk;
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.csproj
@@ -55,6 +55,15 @@
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoFixture, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.4.0.0\lib\net452\AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.AutoNSubstitute, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.AutoNSubstitute.4.0.0\lib\net452\AutoFixture.AutoNSubstitute.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.Xunit2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.Xunit2.4.0.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
@@ -64,16 +73,8 @@
     <Reference Include="NSubstitute, Version=2.0.3.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
       <HintPath>..\packages\NSubstitute.2.0.3\lib\net45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.51.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoNSubstitute, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.AutoNSubstitute.3.51.0\lib\net40\Ploeh.AutoFixture.AutoNSubstitute.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.Xunit2.3.51.0\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/packages.config
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.51.0" targetFramework="net461" />
-  <package id="AutoFixture.AutoNSubstitute" version="3.51.0" targetFramework="net461" />
-  <package id="AutoFixture.Xunit2" version="3.51.0" targetFramework="net461" />
+  <package id="AutoFixture" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.AutoNSubstitute" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="4.0.0" targetFramework="net461" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="JetBrains.Annotations" version="11.1.0" targetFramework="net461" />
   <package id="NSubstitute" version="2.0.3" targetFramework="net461" />

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataAdapterAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataAdapterAttributeTests.cs
@@ -1,0 +1,41 @@
+﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Attributes
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using global::AutoFixture;
+    using Objectivity.AutoFixture.XUnit2.Core.Attributes;
+    using Xunit;
+
+    [Collection("AutoDataAdapterAttribute")]
+    [Trait("Category", "Attributes")]
+    public class AutoDataAdapterAttributeTests
+    {
+        [Fact(DisplayName = "GIVEN fixture WHEN constructor is invoked THEN passed fixture is being adapted")]
+        public void GivenFixture_WhenConstructorIsInvoked_ThenPassedFixtureIsBeingAdapted()
+        {
+            // Arrange
+            IFixture fixture = new Fixture();
+
+            // Act
+            var attribute = new AutoDataAdapterAttribute(fixture);
+
+            // Assert
+            attribute.AdaptedFixture.Should().Be(fixture);
+        }
+
+        [Fact(DisplayName = "GIVEN uninitialized fixture WHEN constructor is invoked THEN exception is thrown")]
+        public void GivenUninitializedFixture_WhenConstructorIsInvoked_ThenExceptionIsThrown()
+        {
+            // Arrange
+            const IFixture fixture = null;
+
+            // Act
+            // Assert
+            Assert.Throws<ArgumentNullException>(() => new AutoDataAdapterAttribute(fixture));
+        }
+    }
+}

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataBaseAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataBaseAttributeTests.cs
@@ -2,11 +2,11 @@
 {
     using System;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
     using Moq;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("AutoDataBaseAttribute")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/InlineAutoDataBaseAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/InlineAutoDataBaseAttributeTests.cs
@@ -2,11 +2,11 @@
 {
     using System;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
     using Moq;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("InlineAutoDataBaseAttribute")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/MemberAutoDataBaseAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/MemberAutoDataBaseAttributeTests.cs
@@ -1,11 +1,11 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Attributes
 {
     using System;
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
     using Moq;
     using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("MemberAutoDataBaseAttribute")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/AutoDataCommonCustomizationTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/AutoDataCommonCustomizationTests.cs
@@ -1,8 +1,8 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Customizations
 {
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("AutoDataCommonCustomization")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/DoNotThrowOnRecursionCustomizationTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/DoNotThrowOnRecursionCustomizationTests.cs
@@ -1,8 +1,8 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Customizations
 {
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("DoNotThrowOnRecursionCustomization")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/IgnoreVirtualMembersCustomizationTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/IgnoreVirtualMembersCustomizationTests.cs
@@ -1,8 +1,8 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Customizations
 {
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("IgnoreVirtualMembersCustomization")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/OmitOnRecursionCustomizationTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Customizations/OmitOnRecursionCustomizationTests.cs
@@ -1,8 +1,8 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.Customizations
 {
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("OmitOnRecursionCustomization")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/FixtureAssertionExtensions.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/FixtureAssertionExtensions.cs
@@ -1,8 +1,8 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests
 {
     using FluentAssertions;
+    using global::AutoFixture;
     using Objectivity.AutoFixture.XUnit2.Core.SpecimenBuilders;
-    using Ploeh.AutoFixture;
 
     internal static class FixtureAssertionExtensions
     {

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/MemberData/MemberAutoDataItemConverterTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/MemberData/MemberAutoDataItemConverterTests.cs
@@ -4,10 +4,10 @@
     using System.Collections.Generic;
     using System.Reflection;
     using FluentAssertions;
+    using global::AutoFixture;
     using Moq;
     using Objectivity.AutoFixture.XUnit2.Core.MemberData;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
     using Xunit;
     using Xunit.Sdk;
 

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Attributes\AutoDataAdapterAttributeTests.cs" />
     <Compile Include="Attributes\AutoDataBaseAttributeTests.cs" />
     <Compile Include="Attributes\InlineAutoDataBaseAttributeTests.cs" />
     <Compile Include="Attributes\MemberAutoDataBaseAttributeTests.cs" />

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
@@ -56,6 +56,12 @@
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoFixture, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.4.0.0\lib\net452\AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.Xunit2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.Xunit2.4.0.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
@@ -68,13 +74,8 @@
     <Reference Include="Moq, Version=4.7.142.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.7.142\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.51.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.Xunit2.3.51.0\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/AutoDataAttributeProviderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/AutoDataAttributeProviderTests.cs
@@ -2,9 +2,10 @@
 {
     using System.Diagnostics.CodeAnalysis;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
+    using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("AutoDataAttributeProvider")]
@@ -20,11 +21,11 @@
             var provider = new AutoDataAttributeProvider();
 
             // Act
-            var dataAttribute = provider.GetAttribute(fixture) as AutoDataAttribute;
+            var dataAttribute = provider.GetAttribute(fixture) as AutoDataAdapterAttribute;
 
             // Assert
             dataAttribute.Should().NotBeNull();
-            dataAttribute.Fixture.Should().Be(fixture);
+            dataAttribute.AdaptedFixture.Should().Be(fixture);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/InlineAutoDataAttributeProviderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/InlineAutoDataAttributeProviderTests.cs
@@ -3,9 +3,10 @@
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using FluentAssertions;
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
+    using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
     using Xunit;
 
     [Collection("InlineAutoDataAttributeProvider")]
@@ -25,7 +26,7 @@
 
             // Assert
             dataAttribute.Should().NotBeNull();
-            dataAttribute.Attributes.FirstOrDefault(a => a is AutoDataAttribute).As<AutoDataAttribute>().Fixture.Should().Be(fixture);
+            dataAttribute.Attributes.FirstOrDefault(a => a is AutoDataAdapterAttribute).As<AutoDataAdapterAttribute>().AdaptedFixture.Should().Be(fixture);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilderTests.cs
@@ -1,9 +1,9 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Tests.SpecimenBuilders
 {
     using FluentAssertions;
+    using global::AutoFixture.Kernel;
     using Moq;
     using Objectivity.AutoFixture.XUnit2.Core.SpecimenBuilders;
-    using Ploeh.AutoFixture.Kernel;
     using Xunit;
 
     [Collection("IgnoreVirtualMembersSpecimenBuilder")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/packages.config
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.51.0" targetFramework="net461" />
-  <package id="AutoFixture.Xunit2" version="3.51.0" targetFramework="net461" />
+  <package id="AutoFixture" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="4.0.0" targetFramework="net461" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="FluentAssertions" version="4.19.4" targetFramework="net461" />
   <package id="Moq" version="4.7.142" targetFramework="net461" />

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataAdapterAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataAdapterAttribute.cs
@@ -8,13 +8,14 @@
     using AutoFixture;
     using global::AutoFixture;
     using global::AutoFixture.Xunit2;
+    using Objectivity.AutoFixture.XUnit2.Core.Common;
 
     internal sealed class AutoDataAdapterAttribute : AutoDataAttribute
     {
         public AutoDataAdapterAttribute(IFixture fixture)
             : base(() => fixture)
         {
-            this.AdaptedFixture = fixture;
+            this.AdaptedFixture = fixture.NotNull(nameof(fixture));
         }
 
         public IFixture AdaptedFixture { get; }

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataAdapterAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataAdapterAttribute.cs
@@ -1,0 +1,22 @@
+﻿namespace Objectivity.AutoFixture.XUnit2.Core.Attributes
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using AutoFixture;
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
+
+    internal sealed class AutoDataAdapterAttribute : AutoDataAttribute
+    {
+        public AutoDataAdapterAttribute(IFixture fixture)
+            : base(() => fixture)
+        {
+            this.AdaptedFixture = fixture;
+        }
+
+        public IFixture AdaptedFixture { get; }
+    }
+}

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataBaseAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataBaseAttribute.cs
@@ -3,10 +3,10 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using global::AutoFixture;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
     using Xunit.Sdk;
 
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/InlineAutoDataBaseAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/InlineAutoDataBaseAttribute.cs
@@ -4,10 +4,10 @@
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Reflection;
+    using global::AutoFixture;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
     using Xunit.Sdk;
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Justification = "Parameter 'values' is exposed with ReadOnlyCollection.")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/MemberAutoDataBaseAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/MemberAutoDataBaseAttribute.cs
@@ -3,11 +3,11 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using global::AutoFixture;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Customizations;
     using Objectivity.AutoFixture.XUnit2.Core.MemberData;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
     using Xunit;
     using Xunit.Sdk;
 

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Customizations/AutoDataCommonCustomization.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Customizations/AutoDataCommonCustomization.cs
@@ -1,7 +1,7 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Customizations
 {
     using Common;
-    using Ploeh.AutoFixture;
+    using global::AutoFixture;
 
     public class AutoDataCommonCustomization : ICustomization
     {

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Customizations/DoNotThrowOnRecursionCustomization.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Customizations/DoNotThrowOnRecursionCustomization.cs
@@ -2,7 +2,7 @@
 {
     using System.Linq;
     using Common;
-    using Ploeh.AutoFixture;
+    using global::AutoFixture;
 
     public class DoNotThrowOnRecursionCustomization : ICustomization
     {

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Customizations/IgnoreVirtualMembersCustomization.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Customizations/IgnoreVirtualMembersCustomization.cs
@@ -1,7 +1,7 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Customizations
 {
     using Common;
-    using Ploeh.AutoFixture;
+    using global::AutoFixture;
     using SpecimenBuilders;
 
     public class IgnoreVirtualMembersCustomization : ICustomization

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Customizations/OmitOnRecursionCustomization.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Customizations/OmitOnRecursionCustomization.cs
@@ -1,7 +1,7 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Customizations
 {
     using Common;
-    using Ploeh.AutoFixture;
+    using global::AutoFixture;
 
     public class OmitOnRecursionCustomization : ICustomization
     {

--- a/src/Objectivity.AutoFixture.XUnit2.Core/MemberData/MemberAutoDataItemConverter.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/MemberData/MemberAutoDataItemConverter.cs
@@ -4,9 +4,9 @@
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
+    using global::AutoFixture;
     using Objectivity.AutoFixture.XUnit2.Core.Common;
     using Objectivity.AutoFixture.XUnit2.Core.Providers;
-    using Ploeh.AutoFixture;
 
     internal class MemberAutoDataItemConverter : IDataItemConverter
     {

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Objectivity.AutoFixture.XUnit2.Core.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Objectivity.AutoFixture.XUnit2.Core.csproj
@@ -59,16 +59,17 @@
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AutoFixture, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.4.0.0\lib\net452\AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoFixture.Xunit2, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.Xunit2.4.0.0\lib\net452\AutoFixture.Xunit2.dll</HintPath>
+    </Reference>
     <Reference Include="JetBrains.Annotations, Version=11.1.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.Annotations.11.1.0\lib\net20\JetBrains.Annotations.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.51.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-    </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.Xunit2.3.51.0\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
@@ -84,6 +85,7 @@
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Attributes\AutoDataAdapterAttribute.cs" />
     <Compile Include="Attributes\AutoDataBaseAttribute.cs" />
     <Compile Include="Attributes\InlineAutoDataBaseAttribute.cs" />
     <Compile Include="Attributes\MemberAutoDataBaseAttribute.cs" />

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Providers/AutoDataAttributeProvider.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Providers/AutoDataAttributeProvider.cs
@@ -1,14 +1,15 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Providers
 {
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
+    using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Xunit.Sdk;
 
     public sealed class AutoDataAttributeProvider : IAutoFixtureAttributeProvider
     {
         public DataAttribute GetAttribute(IFixture fixture)
         {
-            return new AutoDataAttribute(fixture);
+            return new AutoDataAdapterAttribute(fixture);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Providers/IAutoFixtureAttributeProvider.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Providers/IAutoFixtureAttributeProvider.cs
@@ -1,6 +1,6 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Providers
 {
-    using Ploeh.AutoFixture;
+    using global::AutoFixture;
     using Xunit.Sdk;
 
     public interface IAutoFixtureAttributeProvider

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Providers/IAutoFixtureInlineAttributeProvider.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Providers/IAutoFixtureInlineAttributeProvider.cs
@@ -1,6 +1,6 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Providers
 {
-    using Ploeh.AutoFixture;
+    using global::AutoFixture;
     using Xunit.Sdk;
 
     public interface IAutoFixtureInlineAttributeProvider

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Providers/InlineAutoDataAttributeProvider.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Providers/InlineAutoDataAttributeProvider.cs
@@ -1,7 +1,8 @@
 ﻿namespace Objectivity.AutoFixture.XUnit2.Core.Providers
 {
-    using Ploeh.AutoFixture;
-    using Ploeh.AutoFixture.Xunit2;
+    using global::AutoFixture;
+    using global::AutoFixture.Xunit2;
+    using Objectivity.AutoFixture.XUnit2.Core.Attributes;
     using Xunit;
     using Xunit.Sdk;
 
@@ -9,7 +10,7 @@
     {
         public DataAttribute GetAttribute(IFixture fixture, params object[] values)
         {
-            return new CompositeDataAttribute(new InlineDataAttribute(values), new AutoDataAttribute(fixture));
+            return new CompositeDataAttribute(new InlineDataAttribute(values), new AutoDataAdapterAttribute(fixture));
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilder.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilder.cs
@@ -1,7 +1,7 @@
 namespace Objectivity.AutoFixture.XUnit2.Core.SpecimenBuilders
 {
     using System.Reflection;
-    using Ploeh.AutoFixture.Kernel;
+    using global::AutoFixture.Kernel;
 
     internal class IgnoreVirtualMembersSpecimenBuilder : ISpecimenBuilder
     {

--- a/src/Objectivity.AutoFixture.XUnit2.Core/packages.config
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.51.0" targetFramework="net461" />
-  <package id="AutoFixture.Xunit2" version="3.51.0" targetFramework="net461" />
+  <package id="AutoFixture" version="4.0.0" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="4.0.0" targetFramework="net461" />
   <package id="JetBrains.Annotations" version="11.1.0" targetFramework="net461" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net461" developmentDependency="true" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />


### PR DESCRIPTION
Support for AutoFixture v4
- NuGet packages update,
- Namespaces changed from Ploeh.AutoFixture* to global::AutoFixture,
- Added AutoDataAdapterAttribute because of implementation changes in original AutoDataAttribute. Constructor where we could pass the fixture had become obsolete. there is another one introduced with a fixture factory however it is protected.