### PR TITLE
Update .NET Core and NuGet packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,9 +67,9 @@ test_script:
 
     dotnet test -f net48 --no-restore
 
-    dotnet test -f netcoreapp2.2 --no-restore
+    dotnet test -f netcoreapp2.1 --no-restore
 
-    dotnet test -f netcoreapp3.0 --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat=$env:cc /p:Exclude="[xunit*]*" /p:CoverletOutput=$env:APPVEYOR_BUILD_FOLDER\$env:cc\$env:namespace.$env:core_module.xml
+    dotnet test -f netcoreapp3.1 --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat=$env:cc /p:Exclude="[xunit*]*" /p:CoverletOutput=$env:APPVEYOR_BUILD_FOLDER\$env:cc\$env:namespace.$env:core_module.xml
 
     cd $env:APPVEYOR_BUILD_FOLDER/src/$env:namespace.$env:package_module.Tests
 
@@ -79,9 +79,9 @@ test_script:
 
     dotnet test -f net48 --no-restore
 
-    dotnet test -f netcoreapp2.2 --no-restore
+    dotnet test -f netcoreapp2.1 --no-restore
 
-    dotnet test -f netcoreapp3.0 --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat=$env:cc /p:Exclude="[xunit*]*" /p:CoverletOutput=$env:APPVEYOR_BUILD_FOLDER\$env:cc\$env:namespace.$env:package_module.xml
+    dotnet test -f netcoreapp3.1 --no-restore /p:CollectCoverage=true /p:CoverletOutputFormat=$env:cc /p:Exclude="[xunit*]*" /p:CoverletOutput=$env:APPVEYOR_BUILD_FOLDER\$env:cc\$env:namespace.$env:package_module.xml
 
     codecov -f $env:APPVEYOR_BUILD_FOLDER\$env:cc\$env:namespace.$env:core_module.xml --flag unittests
 

--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
@@ -39,17 +39,17 @@
     <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="FakeItEasy" Version="5.4.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net46;net47;net48</TargetFrameworks>
 	<IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\Analysers.Tests.ruleset</CodeAnalysisRuleSet>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
@@ -45,7 +45,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net46;net47;net48</TargetFrameworks>
 	<IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\Analysers.Tests.ruleset</CodeAnalysisRuleSet>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
@@ -39,17 +39,17 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.11.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
@@ -45,7 +45,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Objectivity.AutoFixture.XUnit2.AutoMoq.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq/Objectivity.AutoFixture.XUnit2.AutoMoq.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
@@ -39,17 +39,17 @@
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.11.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net46;net47;net48</TargetFrameworks>
 	<IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\Analysers.Tests.ruleset</CodeAnalysisRuleSet>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
@@ -45,7 +45,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
@@ -38,17 +38,17 @@
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0">
+    <PackageReference Include="coverlet.msbuild" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net46;net47;net48</TargetFrameworks>
 	<IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\Analysers.Tests.ruleset</CodeAnalysisRuleSet>

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
@@ -44,7 +44,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Objectivity.AutoFixture.XUnit2.Core.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Objectivity.AutoFixture.XUnit2.Core.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="AutoFixture" Version="4.11.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Update
- .NET Core to supported versions
- NuGet packages
  - coverlet.msbuild 2.7.0 -> 2.8.0
  - FluentAssertions 5.9.0 -> 5.10.2
  - FxCopAnalyzers 2.9.6 -> 2.9.8
  - Microsoft.NET.Test.Sdk 16.3.0 -> 16.5.0
