### PR TITLE
Remove AutoFixture.Xunit2 dependency from CustomizeAttributeComparer

### DIFF
--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Comparers/CustomizeAttributeComparerTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Comparers/CustomizeAttributeComparerTests.cs
@@ -12,7 +12,7 @@
     [Trait("Category", "Comparers")]
     public class CustomizeAttributeComparerTests
     {
-        private static readonly CustomizeAttributeComparer Comparer = new();
+        private static readonly CustomizeAttributeComparer<FrozenAttribute> Comparer = new();
         private static readonly CustomizeWithAttribute CustomizeAttribute = new(typeof(DoNotThrowOnRecursionCustomization));
         private static readonly FrozenAttribute FrozenAttribute = new();
 

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataAdapterAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataAdapterAttribute.cs
@@ -46,7 +46,7 @@
         {
             var customizeAttributes = p.GetCustomAttributes()
                 .OfType<IParameterCustomizationSource>()
-                .OrderBy(x => x, new CustomizeAttributeComparer());
+                .OrderBy(x => x, new CustomizeAttributeComparer<FrozenAttribute>());
 
             foreach (var ca in customizeAttributes)
             {

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Comparers/CustomizeAttributeComparer.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Comparers/CustomizeAttributeComparer.cs
@@ -3,17 +3,14 @@
     using System.Collections.Generic;
 
     using global::AutoFixture;
-    using global::AutoFixture.Xunit2;
 
-    /// <summary>
-    /// Direct copy from the AutoFixture source code as the original class is internal.
-    /// </summary>
-    internal class CustomizeAttributeComparer : Comparer<IParameterCustomizationSource>
+    internal class CustomizeAttributeComparer<T> : Comparer<IParameterCustomizationSource>
+        where T : IParameterCustomizationSource
     {
         public override int Compare(IParameterCustomizationSource x, IParameterCustomizationSource y)
         {
-            var isXFrozen = x is FrozenAttribute;
-            var isYFrozen = y is FrozenAttribute;
+            var isXFrozen = x is T;
+            var isYFrozen = y is T;
 
             if (isXFrozen && !isYFrozen)
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved comparison logic for parameter customization attributes by introducing a more flexible, generic comparer.
  - Updated internal attribute ordering to use a type-specific comparer, potentially affecting the prioritization of certain customizations.

- **Tests**
  - Adjusted tests to align with the new generic comparer implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->