### PR TITLE
Stop using the legacy updater for NuGet packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
           - "xunit.analyzers"
     ignore:
       - dependency-name: "Moq"
+    experiments:
+      nuget-use-legacy-updater-when-updating-pr: false # Stop using the legacy updater for NuGet packages as it blocks some of the updates
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to disable the legacy updater for NuGet package updates, improving reliability for dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->