### PR TITLE
Enforce conventional commits

### DIFF
--- a/.backlog/tasks/task-3 - Enforce-Conventional-Commits.md
+++ b/.backlog/tasks/task-3 - Enforce-Conventional-Commits.md
@@ -1,10 +1,12 @@
 ---
 id: TASK-3
 title: Enforce Conventional Commits
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - cursor
+  - piotrzajac
 created_date: '2026-04-07 20:55'
-updated_date: '2026-04-07 21:00'
+updated_date: '2026-04-09 09:57'
 labels:
   - ci-cd
   - dx
@@ -21,7 +23,27 @@ Add tooling to enforce the Conventional Commits specification at commit time. Th
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A git commit-msg hook is in place that validates the message against Conventional Commits format
-- [ ] #2 The commit is prevented when the message is non-conforming — not just warned
-- [ ] #3 Setup instructions are added to CONTRIBUTING.md so contributors activate the hooks after cloning
+- [x] #1 A git commit-msg hook is in place that validates the message against Conventional Commits format
+- [x] #2 The commit is prevented when the message is non-conforming — not just warned
+- [x] #3 Setup instructions are added to CONTRIBUTING.md so contributors activate the hooks after cloning
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Implemented Conventional Commit enforcement using Husky.NET + CommitLint.Net with repository-local .NET tools. Final scope delivered: (1) created/updated local tool manifest (`dotnet-tools.json`) with Husky, CommitLint.Net, and dotnet-stryker for aligned tool bootstrap via `dotnet tool restore`; (2) installed Husky hooks and added `.husky/commit-msg` + `.husky/task-runner.json` task that runs `dotnet commit-lint --commit-file ${args} --commit-message-config-file commit-message-config.json`; (3) added `commit-message-config.json` rules for Conventional Commits and allowed types (including `ci`); (4) added CI mirror validation workflow `.github/workflows/commit-message.yml` that validates latest commit message using the same config; (5) updated `CONTRIBUTING.md` Getting Started to restore all local tools and install Husky hooks, added references in commit/mutation sections, and switched mutation command to local-tool invocation (`dotnet dotnet-stryker ...`); (6) enforcement remains strict in local hook and CI workflow with no environment-variable bypass path.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented Husky.NET + CommitLint.Net enforcement with repository-local tooling in `dotnet-tools.json` (Husky, CommitLint.Net, dotnet-stryker) and Conventional Commits rules in `commit-message-config.json`.
+
+Added `.husky/commit-msg` and `.husky/task-runner.json` commit-msg task to run `dotnet commit-lint --commit-file ${args} --commit-message-config-file commit-message-config.json`, blocking invalid commit messages.
+
+Added CI mirror validation in `.github/workflows/commit-message.yml` to lint the latest commit message using the same config.
+
+Updated `CONTRIBUTING.md` to use a single Getting Started bootstrap (`dotnet tool restore` + `dotnet husky install`), added section references for tool usage, and aligned mutation testing to local tool invocation (`dotnet dotnet-stryker -f ../stryker-config.yml`).
+
+Validated behavior locally: valid messages pass and invalid messages fail with non-zero exit.
+<!-- SECTION:NOTES:END -->

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: 📦 cache NuGet tools
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-tools-${{ hashFiles('dotnet-tools.json') }}
+          restore-keys: nuget-tools-
+
       - name: 🛠️ setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -35,15 +42,93 @@ jobs:
       - name: 📦 restore local tools
         run: dotnet tool restore
 
-      - name: ✅ lint commit messages
+      - name: 🧭 select commit range
+        id: commit_range
         run: |
+          switch ("${{ github.event_name }}") {
+            "pull_request" {
+              $baseSha = "${{ github.event.pull_request.base.sha }}"
+              $headSha = "${{ github.event.pull_request.head.sha }}"
+            }
+            "push" {
+              $baseSha = "${{ github.event.before }}"
+              $headSha = "${{ github.sha }}"
+              if ($baseSha -match '^0+$') { $baseSha = $headSha }
+            }
+            default {
+              $baseSha = "${{ github.sha }}"
+              $headSha = "${{ github.sha }}"
+            }
+          }
+
+          "base_sha=$baseSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "head_sha=$headSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: ✅ lint commit messages
+        id: lint
+        run: |
+          $ErrorActionPreference = 'Stop'
           $messagePath = Join-Path $env:RUNNER_TEMP "commit-message.txt"
-          if ("${{ github.event_name }}" -eq "pull_request") {
-            $commits = git log --no-merges --pretty="%H" "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+          $baseSha = "${{ steps.commit_range.outputs.base_sha }}"
+          $headSha = "${{ steps.commit_range.outputs.head_sha }}"
+
+          if ($baseSha -eq $headSha) {
+            $commits = @($headSha)
           } else {
-            $commits = git log -1 --pretty="%H"
+            $commits = @(git rev-list --no-merges --reverse "$baseSha..$headSha" | Where-Object { $_.Trim() })
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
-          foreach ($sha in ($commits -split "`n" | Where-Object { $_ -ne "" })) {
-            git log -1 --pretty="%B" $sha | Out-File -FilePath $messagePath -Encoding utf8
+
+          $totalCommits = $commits.Count
+          Write-Host "Commits selected for linting: $totalCommits"
+          foreach ($commitSha in $commits) {
+            Write-Host " - $commitSha"
+          }
+
+          $failedCount = 0
+          $processedCount = 0
+          foreach ($sha in $commits) {
+            $processedCount++
+            Write-Host "Linting commit [$processedCount/$totalCommits]: $sha"
+            $commitMessage = git log -1 --pretty="%B" $sha
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            $commitMessage | Out-File -FilePath $messagePath -Encoding utf8
             dotnet commit-lint --commit-file $messagePath --commit-message-config-file commit-message-config.json
+            if ($LASTEXITCODE -ne 0) { $failedCount++ }
           }
+
+          "total_commits=$totalCommits" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "failed_commits=$failedCount" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+          if ($failedCount -gt 0) {
+            Write-Error "Commit message lint failed: $failedCount of $totalCommits commit(s) did not pass."
+            exit 1
+          }
+
+          Write-Host "All $processedCount commit(s) passed."
+
+      - name: 📊 write step summary
+        if: always()
+        run: |
+          $baseSha       = "${{ steps.commit_range.outputs.base_sha }}"
+          $headSha       = "${{ steps.commit_range.outputs.head_sha }}"
+          $totalCommits  = "${{ steps.lint.outputs.total_commits }}"
+          $failedCommits = "${{ steps.lint.outputs.failed_commits }}"
+
+          if ($baseSha -eq $headSha) {
+            $rangeDisplay = "${baseSha}"
+          } else {
+            $rangeDisplay = "${baseSha}..${headSha}"
+          }
+
+          $summary = [System.Collections.Generic.List[string]]::new()
+          $summary.Add("## Commit Message Lint")
+          $summary.Add("")
+          $summary.Add("- Event: \`${{ github.event_name }}\`")
+          $summary.Add("- Base SHA: \`$baseSha\`")
+          $summary.Add("- Head SHA: \`$headSha\`")
+          $summary.Add("- Commits: \`$rangeDisplay\`")
+          $summary.Add("- Commits selected: $totalCommits")
+          $summary.Add("- Commits failed: $failedCommits")
+          $summary.Add("")
+          $summary | Add-Content -Path $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -115,10 +115,12 @@ jobs:
           $totalCommits  = "${{ steps.lint.outputs.total_commits }}"
           $failedCommits = "${{ steps.lint.outputs.failed_commits }}"
 
-          $rangeDisplay = if ($baseSha -eq $headSha) {
-            "${baseSha}"
+          if ($baseSha -eq $headSha) {
+            $rangeLabel   = "🔖 Commit"
+            $rangeDisplay = $baseSha
           } else {
-            "${baseSha}..${headSha}"
+            $rangeLabel   = "🔀 Commits"
+            $rangeDisplay = "${baseSha}..${headSha}"
           }
 
           $passed = [string]::IsNullOrEmpty($failedCommits) -or $failedCommits -eq "0"
@@ -135,8 +137,8 @@ jobs:
           $summary.Add("")
           $summary.Add("---")
           $summary.Add("")
-          $summary.Add("- 🔀 Range: ``$rangeDisplay``")
-          $summary.Add("- Commits selected: $totalCommits")
-          $summary.Add("- Commits failed: $failedCommits")
+          $summary.Add("- ${rangeLabel}: ``$rangeDisplay``")
+          $summary.Add("- 📋 Selected: ``$totalCommits``")
+          $summary.Add("- 🚨 Failed: ``$failedCommits``")
           $summary.Add("")
           $summary | Add-Content -Path $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -34,11 +34,6 @@ jobs:
           key: nuget-tools-${{ hashFiles('dotnet-tools.json') }}
           restore-keys: nuget-tools-
 
-      - name: 🛠️ setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: 8.0.x
-
       - name: 📦 restore local tools
         run: dotnet tool restore
 

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -110,7 +110,8 @@ jobs:
           $totalCommits  = "${{ steps.lint.outputs.total_commits }}"
           $failedCommits = "${{ steps.lint.outputs.failed_commits }}"
 
-          if ($baseSha -eq $headSha) {
+          $hasSingleCommit = $baseSha -eq $headSha
+          if ($hasSingleCommit) {
             $rangeLabel   = "🔖 Commit"
             $rangeDisplay = $baseSha
           } else {
@@ -118,11 +119,15 @@ jobs:
             $rangeDisplay = "${baseSha}..${headSha}"
           }
 
-          $passed = [string]::IsNullOrEmpty($failedCommits) -or $failedCommits -eq "0"
-          $status = if ($passed) {
-            "✅ All $totalCommits commit(s) passed."
+          $isLintSuccessful = "${{ steps.lint.outcome }}" -eq 'success'
+          $status = if ($isLintSuccessful) {
+            if ($failedCommits -eq "0") {
+              "✅ All $totalCommits commit(s) passed."
+            } else {
+              "❌ $failedCommits of $totalCommits commit(s) failed."
+            }
           } else {
-            "❌ $failedCommits of $totalCommits commit(s) failed."
+            "🚨 Linting failed before producing any stats."
           }
 
           $summary = [System.Collections.Generic.List[string]]::new()
@@ -133,7 +138,9 @@ jobs:
           $summary.Add("---")
           $summary.Add("")
           $summary.Add("- ${rangeLabel}: ``$rangeDisplay``")
-          $summary.Add("- 📋 Selected: ``$totalCommits``")
-          $summary.Add("- 🚨 Failed: ``$failedCommits``")
+          if ($isLintSuccessful) {
+            $summary.Add("- 📋 Selected: ``$totalCommits``")
+            $summary.Add("- 🚨 Failed: ``$failedCommits``")
+          }
           $summary.Add("")
-          $summary | Add-Content -Path $env:GITHUB_STEP_SUMMARY
+          $summary | Add-Content -Path $env:GITHUB_STEP_SUMMARY -Encoding utf8

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -107,7 +107,7 @@ jobs:
 
           Write-Host "All $processedCount commit(s) passed."
 
-      - name: 📊 write step summary
+      - name: 📊 write summary
         if: always()
         run: |
           $baseSha       = "${{ steps.commit_range.outputs.base_sha }}"
@@ -115,19 +115,27 @@ jobs:
           $totalCommits  = "${{ steps.lint.outputs.total_commits }}"
           $failedCommits = "${{ steps.lint.outputs.failed_commits }}"
 
-          if ($baseSha -eq $headSha) {
-            $rangeDisplay = "${baseSha}"
+          $rangeDisplay = if ($baseSha -eq $headSha) {
+            "${baseSha}"
           } else {
-            $rangeDisplay = "${baseSha}..${headSha}"
+            "${baseSha}..${headSha}"
+          }
+
+          $passed = [string]::IsNullOrEmpty($failedCommits) -or $failedCommits -eq "0"
+          $status = if ($passed) {
+            "✅ All $totalCommits commit(s) passed."
+          } else {
+            "❌ $failedCommits of $totalCommits commit(s) failed."
           }
 
           $summary = [System.Collections.Generic.List[string]]::new()
-          $summary.Add("## Commit Message Lint")
+          $summary.Add("## 📝 Commit Message Lint")
           $summary.Add("")
-          $summary.Add("- Event: \`${{ github.event_name }}\`")
-          $summary.Add("- Base SHA: \`$baseSha\`")
-          $summary.Add("- Head SHA: \`$headSha\`")
-          $summary.Add("- Commits: \`$rangeDisplay\`")
+          $summary.Add("**$status**")
+          $summary.Add("")
+          $summary.Add("---")
+          $summary.Add("")
+          $summary.Add("- 🔀 Range: ``$rangeDisplay``")
           $summary.Add("- Commits selected: $totalCommits")
           $summary.Add("- Commits failed: $failedCommits")
           $summary.Add("")

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,49 @@
+name: '📝 Commit Message Lint'
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+    - 'master'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: pwsh
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: 📥 checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: 🛠️ setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: 📦 restore local tools
+        run: dotnet tool restore
+
+      - name: ✅ lint commit messages
+        run: |
+          $messagePath = Join-Path $env:RUNNER_TEMP "commit-message.txt"
+          if ("${{ github.event_name }}" -eq "pull_request") {
+            $commits = git log --no-merges --pretty="%H" "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
+          } else {
+            $commits = git log -1 --pretty="%H"
+          }
+          foreach ($sha in ($commits -split "`n" | Where-Object { $_ -ne "" })) {
+            git log -1 --pretty="%B" $sha | Out-File -FilePath $messagePath -Encoding utf8
+            dotnet commit-lint --commit-file $messagePath --commit-message-config-file commit-message-config.json
+          }

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -56,8 +56,8 @@ jobs:
             }
           }
 
-          "base_sha=$baseSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "head_sha=$headSha" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "base_sha=$baseSha" >> $env:GITHUB_OUTPUT
+          "head_sha=$headSha" >> $env:GITHUB_OUTPUT
 
       - name: ✅ lint commit messages
         id: lint
@@ -92,8 +92,8 @@ jobs:
             if ($LASTEXITCODE -ne 0) { $failedCount++ }
           }
 
-          "total_commits=$totalCommits" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-          "failed_commits=$failedCount" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "total_commits=$totalCommits" >> $env:GITHUB_OUTPUT
+          "failed_commits=$failedCount" >> $env:GITHUB_OUTPUT
 
           if ($failedCount -gt 0) {
             Write-Error "Commit message lint failed: $failedCount of $totalCommits commit(s) did not pass."

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+dotnet husky run --group commit-msg --args "$1"

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,17 @@
+{
+   "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
+   "tasks": [
+      {
+         "name": "commit-message-linter",
+         "group": "commit-msg",
+         "command": "dotnet",
+         "args": [
+            "commit-lint",
+            "--commit-file",
+            "${args}",
+            "--commit-message-config-file",
+            "commit-message-config.json"
+         ]
+      }
+   ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,10 +91,9 @@ dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln --framework net8.0
 # Pack NuGet packages (outputs to src/<project>/bin/Release/)
 dotnet pack src/Objectivity.AutoFixture.XUnit2.AutoMock.sln --configuration Release
 
-# Run mutation tests (install the tool once globally, must run from src/ — Stryker resolves projects relative to its working directory)
-dotnet tool install -g dotnet-stryker
+# Run mutation tests (dotnet-stryker is a repository-local tool; must run from src/ — Stryker resolves projects relative to its working directory)
 cd src
-dotnet stryker -f ../stryker-config.yml
+dotnet dotnet-stryker -f ../stryker-config.yml
 ```
 
 **Important:** `dotnet build` enforces code style via `EnforceCodeStyleInBuild=true` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,13 @@ Thanks for taking the time to contribute. This project is a C# NuGet library col
 
 ```bash
 git clone https://github.com/Accenture/AutoFixture.XUnit2.AutoMock.git
+cd AutoFixture.XUnit2.AutoMock
+
+# Restore all repository-local .NET tools (Husky.NET, CommitLint.Net, and dotnet-stryker)
+dotnet tool restore
+
+# Activate local Git hooks managed by Husky.NET
+dotnet husky install
 ```
 
 All build, test, and pack commands are in the [Build / Test / Pack](#build--test--pack) section below.
@@ -51,12 +58,11 @@ dotnet pack src/Objectivity.AutoFixture.XUnit2.AutoMock.sln --configuration Rele
 
 ## Mutation Testing (Stryker.NET)
 
-Mutation testing is executed via Stryker.NET. Install the tool globally once, then run it from the `src/` directory (the config is resolved relative to `src/`):
+Mutation testing is executed via Stryker.NET. The `dotnet-stryker` tool is installed in [Getting Started](#getting-started), so you can run it from the `src/` directory (the config is resolved relative to `src/`):
 
 ```bash
-dotnet tool install -g dotnet-stryker
 cd src
-dotnet stryker -f ../stryker-config.yml
+dotnet dotnet-stryker -f ../stryker-config.yml
 ```
 
 ## Code Style
@@ -73,6 +79,10 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
   - `fix(tests): correct GIVEN/WHEN/THEN naming`
   - `chore(ci): update build instructions`
   - `docs: clarify local development setup`
+
+Commit messages are validated by a local `commit-msg` hook (`Husky.NET` + `CommitLint.Net`), so invalid messages are rejected before the commit is created.
+
+The required local tools and hook activation are configured in [Getting Started](#getting-started) (`dotnet tool restore` + `dotnet husky install`).
 
 ## Work Tracking
 

--- a/commit-message-config.json
+++ b/commit-message-config.json
@@ -20,7 +20,7 @@
         "ci"
       ],
       "scopes": {
-        "enabled": false,
+        "enabled": true,
         "global": [],
         "per-type": {}
       }

--- a/commit-message-config.json
+++ b/commit-message-config.json
@@ -1,0 +1,29 @@
+{
+  "config": {
+    "max-subject-length": {
+      "enabled": true,
+      "value": 90
+    },
+    "conventional-commit": {
+      "enabled": true,
+      "types": [
+        "feat",
+        "fix",
+        "refactor",
+        "build",
+        "chore",
+        "style",
+        "test",
+        "docs",
+        "perf",
+        "revert",
+        "ci"
+      ],
+      "scopes": {
+        "enabled": false,
+        "global": [],
+        "per-type": {}
+      }
+    }
+  }
+}

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.9.1",
+      "commands": [
+        "husky"
+      ],
+      "rollForward": true
+    },
+    "commitlint.net": {
+      "version": "0.8.0",
+      "commands": [
+        "commit-lint"
+      ],
+      "rollForward": true
+    },
+    "dotnet-stryker": {
+      "version": "4.14.0",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": true
+    }
+  }
+}


### PR DESCRIPTION
# Summary

Enforce conventional commits

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)
- [x] `dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes with no warnings
- [x] `dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes on all framework slices
- [x] Code coverage remains at least at the level prior the change (verified by Codecov)
- [x] Mutation score remains at least at the level prior the change (verified by Stryker)
- [x] New tests follow the GIVEN/WHEN/THEN naming convention and AAA structure (see [AGENTS.md](../AGENTS.md))
- [x] No new `[SuppressMessage]` without a justification comment
- [x] No `// TODO:` comments added — open a GitHub issue instead
- [x] No new dependencies introduced that are incompatible with the MIT license (verified by FOSSA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforces Conventional Commits: local commit hooks block invalid messages and CI validates commit messages on PRs and pushes, failing when messages don't comply.
  * Adds repository-local tool configuration to run commit linting and related tooling.

* **Documentation**
  * Updated setup instructions to restore local tools and enable local commit hooks; mutation testing now uses repo-local tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->