### PR TITLE
No commit linting on push to master

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -3,9 +3,6 @@ name: '📝 Commit Message Lint'
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches:
-    - 'master'
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: 📦 cache NuGet tools
+      - name: 💾 cache NuGet tools
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
@@ -42,11 +42,6 @@ jobs:
               $baseSha = "${{ github.event.pull_request.base.sha }}"
               $headSha = "${{ github.event.pull_request.head.sha }}"
             }
-            "push" {
-              $baseSha = "${{ github.event.before }}"
-              $headSha = "${{ github.sha }}"
-              if ($baseSha -match '^0+$') { $baseSha = $headSha }
-            }
             default {
               $baseSha = "${{ github.sha }}"
               $headSha = "${{ github.sha }}"
@@ -56,7 +51,7 @@ jobs:
           "base_sha=$baseSha" >> $env:GITHUB_OUTPUT
           "head_sha=$headSha" >> $env:GITHUB_OUTPUT
 
-      - name: ✅ lint commit messages
+      - name: 🔬 lint commit messages
         id: lint
         run: |
           $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
# Summary

No commit linting on push to master

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)
- [x] `dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes with no warnings
- [x] `dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes on all framework slices
- [x] Code coverage remains at least at the level prior the change (verified by Codecov)
- [x] Mutation score remains at least at the level prior the change (verified by Stryker)
- [x] New tests follow the GIVEN/WHEN/THEN naming convention and AAA structure (see [AGENTS.md](../AGENTS.md))
- [x] No new `[SuppressMessage]` without a justification comment
- [x] No `// TODO:` comments added — open a GitHub issue instead
- [x] No new dependencies introduced that are incompatible with the MIT license (verified by FOSSA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to narrow activation to pull request events and simplify commit-range selection.
  * Adjusted CI step labels for linting and package caching for clearer build output.

---

Note: No user-facing functionality changed; this release contains internal CI configuration updates only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->