### PR TITLE
fix(dependabot): Follow Conventional Commits

### DIFF
--- a/.backlog/tasks/task-8 - Fix-Dependabot-commit-messages-to-follow-Conventional-Commits.md
+++ b/.backlog/tasks/task-8 - Fix-Dependabot-commit-messages-to-follow-Conventional-Commits.md
@@ -29,11 +29,16 @@ After TASK-3 enforced Conventional Commits for all contributors, the Dependabot 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-Added `commit-message` configuration with `prefix: "chore"` and `include: "scope"` to both the `nuget` and `github-actions` entries in `.github/dependabot.yml`. Dependabot appends the package-manager name as the scope automatically, producing messages like `chore(nuget): bump ...` and `chore(github-actions): bump ...`.
+Added `commit-message` configuration to both entries in `.github/dependabot.yml`:
+
+- NuGet entry: `prefix: "chore(nuget)"`
+- GitHub Actions entry: `prefix: "chore(github-actions)"`
+
+`include: "scope"` was intentionally omitted — that option produces `deps`/`deps-dev` as the scope (dependency-type based), not the ecosystem name. Embedding the scope directly in `prefix` is the only way to produce ecosystem-specific scopes.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Dependabot `commit-message.include: "scope"` uses the package-ecosystem name as the scope (e.g. `nuget`, `github-actions`), which satisfies the Conventional Commits scope requirement without any custom scripting.
+`commit-message.include: "scope"` in Dependabot produces `chore(deps):` or `chore(deps-dev):` based on the dependency type — it does NOT use the ecosystem name as the scope. To get `chore(nuget):` and `chore(github-actions):`, the scope must be baked directly into the `prefix` value and `include: "scope"` must be omitted.
 <!-- SECTION:NOTES:END -->

--- a/.backlog/tasks/task-8 - Fix-Dependabot-commit-messages-to-follow-Conventional-Commits.md
+++ b/.backlog/tasks/task-8 - Fix-Dependabot-commit-messages-to-follow-Conventional-Commits.md
@@ -4,6 +4,7 @@ title: Fix Dependabot commit messages to follow Conventional Commits
 status: Done
 assignee:
   - piotrzajac
+  - claude
 created_date: '2026-04-12'
 updated_date: '2026-04-12'
 labels:

--- a/.backlog/tasks/task-8 - Fix-Dependabot-commit-messages-to-follow-Conventional-Commits.md
+++ b/.backlog/tasks/task-8 - Fix-Dependabot-commit-messages-to-follow-Conventional-Commits.md
@@ -1,0 +1,39 @@
+---
+id: TASK-8
+title: Fix Dependabot commit messages to follow Conventional Commits
+status: Done
+assignee:
+  - piotrzajac
+created_date: '2026-04-12'
+updated_date: '2026-04-12'
+labels:
+  - ci-cd
+  - fix
+dependencies:
+  - TASK-3
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+After TASK-3 enforced Conventional Commits for all contributors, the Dependabot configuration in `.github/dependabot.yml` was not updated to produce commit messages in the same format. Dependabot's auto-generated commit messages (e.g. `Bump Moq from 4.20.0 to 4.20.1`) would fail the commit-message CI validation workflow introduced in TASK-3.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Dependabot NuGet update commits follow the format `chore(nuget): bump <package> from <old> to <new>`
+- [x] #2 Dependabot GitHub Actions update commits follow the format `chore(github-actions): bump <action> from <old> to <new>`
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Added `commit-message` configuration with `prefix: "chore"` and `include: "scope"` to both the `nuget` and `github-actions` entries in `.github/dependabot.yml`. Dependabot appends the package-manager name as the scope automatically, producing messages like `chore(nuget): bump ...` and `chore(github-actions): bump ...`.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Dependabot `commit-message.include: "scope"` uses the package-ecosystem name as the scope (e.g. `nuget`, `github-actions`), which satisfies the Conventional Commits scope requirement without any custom scripting.
+<!-- SECTION:NOTES:END -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   - package-ecosystem: "nuget"
     directories:
       - "**/*"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -26,6 +29,9 @@ updates:
       - dependency-name: "Moq"
   - package-ecosystem: "github-actions"
     directory: "/"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
     schedule:
       interval: "weekly"
       day: "sunday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
     directories:
       - "**/*"
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: "chore(nuget)"
     schedule:
       interval: "weekly"
       day: "sunday"
@@ -30,8 +29,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     commit-message:
-      prefix: "chore"
-      include: "scope"
+      prefix: "chore(github-actions)"
     schedule:
       interval: "weekly"
       day: "sunday"


### PR DESCRIPTION
# Summary

Dependabot should follow conventional commits

<!-- Placeholder in the PR description that CodeRabbit replaces with the high-level summary. -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized Dependabot-generated commit messages to improve commit history clarity. Dependency update commits (including package manager and automation updates) now use consistent prefixes and scopes so automated updates appear with predictable, readable messages. This aligns automated commits with the project’s commit-message conventions and CI validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)
- [x] `dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes with no warnings
- [x] `dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes on all framework slices
- [x] Code coverage remains at least at the level prior the change (verified by Codecov)
- [x] Mutation score remains at least at the level prior the change (verified by Stryker)
- [x] New tests follow the GIVEN/WHEN/THEN naming convention and AAA structure (see [AGENTS.md](../AGENTS.md))
- [x] No new `[SuppressMessage]` without a justification comment
- [x] No `// TODO:` comments added — open a GitHub issue instead
- [x] No new dependencies introduced that are incompatible with the MIT license (verified by FOSSA)
