### PR TITLE
fix(snyk): Update action and split report upload

### DIFF
--- a/.backlog/tasks/task-11 - Fix-snyk-workflow.md
+++ b/.backlog/tasks/task-11 - Fix-snyk-workflow.md
@@ -1,0 +1,51 @@
+---
+id: TASK-11
+title: Fix snyk workflow
+status: Done
+assignee:
+  - claude
+  - piotrzajac
+created_date: '2026-04-12'
+updated_date: '2026-04-12'
+labels: [ci-cd, sec]
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Two issues need fixing in `.github/workflows/snyk.yml`:
+
+### Issue 1 — Deprecated action
+
+All three scan/monitor steps use `snyk/actions/dotnet@master`, which is officially
+deprecated and no longer supported by Snyk (no .NET-specific replacement exists).
+
+The recommended migration is `snyk/actions/setup@master` (installs the Snyk CLI only)
+combined with explicit `run: snyk ...` commands. Since the workflow already runs on
+`ubuntu-latest`, the Docker-based `setup` action works without any runner change.
+
+### Issue 2 — Multiple SARIF runs under the same category
+
+The single `upload-sarif` step points to the `snyk/` directory, which contains two
+SARIF files (`opensource.sarif` and `code.sarif`). GitHub Code Scanning no longer
+allows multiple SARIF runs uploaded under the same category (announced 2025-07-21),
+causing the workflow to fail with:
+
+> The CodeQL Action does not support uploading multiple SARIF runs with the same
+> category. Please update your workflow to upload a single run per category.
+
+**Fix:** replace the single directory upload with two steps, each pointing to a
+specific file with a distinct `category`. The `category` parameter creates an
+independent slot in the GitHub Advanced Security dashboard — uploads coexist and
+neither overwrites the other.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+- [x] #1 All three `snyk/actions/dotnet@master` steps are replaced with `snyk/actions/setup@master` + `run:` commands
+- [x] #2 The single `upload-sarif` directory step is replaced by two file-specific steps
+- [x] #3 Each upload step specifies a distinct `category` (`snyk-opensource` and `snyk-code`)
+- [x] #4 Both upload steps retain `if: ${{ always() }}` so results upload even when scans report findings
+- [x] #5 The workflow runs without error

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -45,30 +45,31 @@ jobs:
           if ($LastExitCode -ne 0) {
             throw "dotnet restore failed with exit code $LastExitCode"
           }
+      - name: 🏗️ setup snyk
+        uses: snyk/actions/setup@master
       - name: 🔬 snyk opensource scan
-        uses: snyk/actions/dotnet@master
+        run: snyk test --sarif-file-output=snyk/opensource.sarif --all-projects --exclude=Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests,Objectivity.AutoFixture.XUnit2.AutoMoq.Tests,Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests,Objectivity.AutoFixture.XUnit2.Core.Tests
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --sarif-file-output=snyk/opensource.sarif --all-projects --exclude=Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests,Objectivity.AutoFixture.XUnit2.AutoMoq.Tests,Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests,Objectivity.AutoFixture.XUnit2.Core.Tests
       - name: 🔬 snyk code scan
-        uses: snyk/actions/dotnet@master
+        run: snyk code test --sarif-file-output=snyk/code.sarif
         continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --sarif-file-output=snyk/code.sarif
-          command: code test
       - name: 📈 snyk monitor
-        uses: snyk/actions/dotnet@master
+        run: snyk monitor --all-projects --exclude=Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests,Objectivity.AutoFixture.XUnit2.AutoMoq.Tests,Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests,Objectivity.AutoFixture.XUnit2.Core.Tests
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --all-projects --exclude=Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests,Objectivity.AutoFixture.XUnit2.AutoMoq.Tests,Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests,Objectivity.AutoFixture.XUnit2.Core.Tests
-          command: monitor
-      - name: 📊 upload sarif file for GitHub Advanced Security Dashboard
+      - name: 📊 upload opensource sarif for GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: snyk
+          sarif_file: snyk/opensource.sarif
+          category: snyk-opensource
+        if: ${{ always() }}
+      - name: 📊 upload code sarif for GitHub Advanced Security Dashboard
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: snyk/code.sarif
+          category: snyk-code
         if: ${{ always() }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -46,7 +46,7 @@ jobs:
             throw "dotnet restore failed with exit code $LastExitCode"
           }
       - name: 🏗️ setup snyk
-        uses: snyk/actions/setup@master
+        uses: snyk/actions/setup@v1.0.0
       - name: 🔬 snyk opensource scan
         run: snyk test --sarif-file-output=snyk/opensource.sarif --all-projects --exclude=Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests,Objectivity.AutoFixture.XUnit2.AutoMoq.Tests,Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests,Objectivity.AutoFixture.XUnit2.Core.Tests
         continue-on-error: true
@@ -66,10 +66,10 @@ jobs:
         with:
           sarif_file: snyk/opensource.sarif
           category: snyk-opensource
-        if: ${{ always() }}
+        if: ${{ always() && hashFiles('snyk/opensource.sarif') != '' }}
       - name: 📊 upload code sarif for GitHub Advanced Security Dashboard
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snyk/code.sarif
           category: snyk-code
-        if: ${{ always() }}
+        if: ${{ always() && hashFiles('snyk/code.sarif') != '' }}

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -45,7 +45,7 @@ jobs:
           if ($LastExitCode -ne 0) {
             throw "dotnet restore failed with exit code $LastExitCode"
           }
-      - name: 🏗️ setup snyk
+      - name: 🛠️ setup snyk
         uses: snyk/actions/setup@v1.0.0
       - name: 🔬 snyk opensource scan
         run: snyk test --sarif-file-output=snyk/opensource.sarif --all-projects --exclude=Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests,Objectivity.AutoFixture.XUnit2.AutoMoq.Tests,Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests,Objectivity.AutoFixture.XUnit2.Core.Tests


### PR DESCRIPTION
# Summary

<!-- Placeholder in the PR description that CodeRabbit replaces with the high-level summary. -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a backlog task describing required Snyk CI workflow fixes and acceptance criteria.

* **Chores**
  * Updated the CI security scan workflow to use the current Snyk setup and explicit scan commands.
  * Split security scan result uploads into separate, clearly categorized submissions for opensource and code scans; preserved conditional upload behavior to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)
- [x] `dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes with no warnings
- [x] `dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes on all framework slices
- [x] Code coverage remains at least at the level prior the change (verified by Codecov)
- [x] Mutation score remains at least at the level prior the change (verified by Stryker)
- [x] New tests follow the GIVEN/WHEN/THEN naming convention and AAA structure (see [AGENTS.md](../AGENTS.md))
- [x] No new `[SuppressMessage]` without a justification comment
- [x] No `// TODO:` comments added — open a GitHub issue instead
- [x] No new dependencies introduced that are incompatible with the MIT license (verified by FOSSA)
