### PR TITLE
fix(common): Eliminate intermediate array allocations

### DIFF
--- a/.backlog/tasks/task-12 - Eliminate-intermediate-array-allocations.md
+++ b/.backlog/tasks/task-12 - Eliminate-intermediate-array-allocations.md
@@ -1,0 +1,83 @@
+---
+id: TASK-12
+title: "Eliminate intermediate array allocations"
+status: Done
+assignee:
+  - claude
+  - piotrzajac
+created_date: '2026-04-12'
+updated_date: '2026-04-12'
+labels:
+  - fix
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+In `src/Objectivity.AutoFixture.XUnit2.Core/Common/EnumerableExtensions.cs`, the method
+`TryGetEnumerableSingleTypeArgument` contained a conditional branch that built an
+interfaces array:
+
+```csharp
+var interfaces = type.IsInterface
+    ? type.GetInterfaces().Concat(new[] { type }).ToArray()
+    : type.GetInterfaces();
+
+var genericInterface = Array.Find(
+    interfaces,
+    x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+```
+
+This had two problems:
+
+1. **Equivalent Stryker mutation (survived):** including or excluding the concrete type in
+   the array made no observable difference to the `IEnumerable<>` discovery logic, so
+   Stryker correctly flagged the conditional as an equivalent mutation that can never be
+   killed by a test.
+2. **Unnecessary allocations:** for interface types, `.Concat(new[] { type }).ToArray()`
+   allocated three objects (the single-element array, the concatenation enumerator, and
+   the resulting array) that served no real purpose.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [x] #1 `TryGetEnumerableSingleTypeArgument` no longer uses a conditional branch to include the type itself in the interfaces array
+- [x] #2 No intermediate arrays are allocated during the `IEnumerable<>` discovery
+- [x] #3 The previously surviving Stryker equivalent mutation is eliminated
+- [x] #4 All existing tests continue to pass with zero build warnings
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Replace the conditional array-building approach with a two-step check that avoids any
+intermediate collection to first search the declared interfaces (where `IEnumerable<T>` will be found for
+concrete collection types), then falls back to checking the type itself (handles the case
+where `type` is directly `IEnumerable<T>`).
+<!-- SECTION:PLAN:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Applied to `src/Objectivity.AutoFixture.XUnit2.Core/Common/EnumerableExtensions.cs`.
+
+The conditional branch that built an intermediate interfaces array was replaced with a
+two-step null-coalescing expression:
+
+```csharp
+var genericInterface = Array.Find(type.GetInterfaces(), IsGenericEnumerable)
+    ?? (IsGenericEnumerable(type) ? type : null);
+```
+
+A private static helper `IsGenericEnumerable(Type)` was extracted to name the predicate
+and allow reuse in both branches. The change:
+
+- Eliminates all three intermediate object allocations present in the original interface-type branch
+- Kills the equivalent Stryker mutation by removing the conditional that had no observable effect
+- Keeps the same logical behaviour: concrete types are found via their interfaces; types
+  that are themselves `IEnumerable<T>` are found via the fallback check
+- Build passes with zero warnings; all tests pass across `net8.0`, `net472`, and `net48`
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,29 +75,41 @@ eliminating boilerplate setup in unit tests.
 All commands run from the **repository root** unless specified otherwise.
 CI runs on **Windows** because `net472`/`net48` require it.
 
-```bash
-# Build entire solution
-dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln
+### Build
 
-# Run all tests (all framework slices: net8.0, net472, net48 on Windows)
+```bash
+dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln
+```
+
+Enforces code style via `EnforceCodeStyleInBuild=true` and `TreatWarningsAsErrors=true`. A build that passes without warnings means all analyzers are satisfied.
+
+### Test
+
+```bash
+# All framework slices (net8.0, net472, net48 on Windows)
 dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln
 
-# Run tests for a specific module only
+# Specific module only
 dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMoq.sln
 
-# Run tests for a specific framework
+# Specific framework
 dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln --framework net8.0
+```
 
-# Pack NuGet packages (outputs to src/<project>/bin/Release/)
+### Pack
+
+```bash
+# Outputs to src/<project>/bin/Release/
 dotnet pack src/Objectivity.AutoFixture.XUnit2.AutoMock.sln --configuration Release
+```
 
-# Run mutation tests (dotnet-stryker is a repository-local tool; must run from src/ — Stryker resolves projects relative to its working directory)
+### Mutation Tests
+
+```bash
+# dotnet-stryker is a repository-local tool; must run from src/
 cd src
 dotnet dotnet-stryker -f ../stryker-config.yml
 ```
-
-**Important:** `dotnet build` enforces code style via `EnforceCodeStyleInBuild=true` and
-`TreatWarningsAsErrors=true`. A build that passes without warnings means all analyzers are satisfied.
 
 ---
 
@@ -429,7 +441,17 @@ These rules apply to all AI coding assistants working in this repository.
 ### Before Making Changes
 
 - **Propose before acting** on any non-trivial change (new attribute, refactor, CI change). Describe the approach and wait for approval.
+- **Suggest creating a backlog task** if one does not already exist before implementation begins. Search the backlog first to avoid duplicates.
+- **Suggest a branch checkout** for any non-trivial change before implementation begins. Use the Conventional Commits type as a prefix and a short kebab-case description, e.g. `git checkout -b fix/enumerable-extensions-allocation`. Common prefixes: `feat/`, `fix/`, `refactor/`, `chore/`, `ci/`, `docs/`.
 - **Prefer `dotnet build` over reading files** to verify correctness — the analyser stack catches style and correctness issues that are hard to spot by inspection alone.
+
+### After Making Changes
+
+After any C# code change, offer to run the following steps in order — do not run them automatically, as the user may choose to defer:
+
+1. [**Build**](#build)
+2. [**Test**](#test)
+3. [**Mutation Tests**](#mutation-tests) *(slow — typically run before raising a PR)*
 
 ### Committing
 

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Common/EnumerableExtensions.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Common/EnumerableExtensions.cs
@@ -23,13 +23,8 @@
                 return true;
             }
 
-            var interfaces = type.IsInterface
-                ? type.GetInterfaces().Concat(new[] { type }).ToArray()
-                : type.GetInterfaces();
-
-            var genericInterface = Array.Find(
-                interfaces,
-                x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IEnumerable<>));
+            var genericInterface = Array.Find(type.GetInterfaces(), IsGenericEnumerable)
+                ?? (IsGenericEnumerable(type) ? type : null);
             if (genericInterface is not null)
             {
                 var typeArguments = genericInterface.GenericTypeArguments;
@@ -48,6 +43,11 @@
         {
             var method = BuildTypedArrayMethodInfo.MakeGenericMethod(itemType.NotNull(nameof(itemType)));
             return method.Invoke(null, new object[] { items.NotNull(nameof(items)) });
+        }
+
+        private static bool IsGenericEnumerable(Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>);
         }
 
         private static TElementType[] BuildTypedArray<TElementType>(IEnumerable items)


### PR DESCRIPTION
# Summary

<!-- Placeholder in the PR description that CodeRabbit replaces with the high-level summary. -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated developer workflow guidance with post-change build and test procedures.

* **Chores**
  * Improved internal array allocation performance.
  * Added backlog task tracking implementation improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)
- [x] `dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes with no warnings
- [x] `dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes on all framework slices
- [x] Code coverage remains at least at the level prior the change (verified by Codecov)
- [x] Mutation score remains at least at the level prior the change (verified by Stryker)
- [x] New tests follow the GIVEN/WHEN/THEN naming convention and AAA structure (see [AGENTS.md](../AGENTS.md))
- [x] No new `[SuppressMessage]` without a justification comment
- [x] No `// TODO:` comments added — open a GitHub issue instead
- [x] No new dependencies introduced that are incompatible with the MIT license (verified by FOSSA)
