### PR TITLE
chore(tests): Upgrade test projects from net8.0 to net10.0

### DIFF
--- a/.backlog/completed/task-13 - Upgrade-test-projects-from-net8-to-net10.md
+++ b/.backlog/completed/task-13 - Upgrade-test-projects-from-net8-to-net10.md
@@ -1,8 +1,10 @@
 ---
 id: TASK-13
 title: 'Upgrade test projects from net8.0 to net10.0'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - claude
+  - piotrzajac
 created_date: '2026-04-12'
 labels:
   - feature
@@ -30,10 +32,10 @@ Replace `net8.0` with `net10.0` in all four test projects. .NET 10 is LTS (suppo
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 `net10.0` replaces `net8.0` in the `<TargetFrameworks>` in all four test `.csproj` files
-- [ ] #2 All tests pass across `net10.0`, `net472`, and `net48`
-- [ ] #3 CI pipeline passes without errors on all framework slices
-- [ ] #4 `AGENTS.md` Target Frameworks table is updated to reflect `net10.0` for test projects
+- [x] #1 `net10.0` replaces `net8.0` in the `<TargetFrameworks>` in all four test `.csproj` files
+- [x] #2 All tests pass across `net10.0`, `net472`, and `net48`
+- [x] #3 CI pipeline passes without errors on all framework slices
+- [x] #4 `AGENTS.md` Target Frameworks table is updated to reflect `net10.0` for test projects
 <!-- AC:END -->
 
 ## Files Affected

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -61,14 +61,11 @@ body:
     validations:
       required: true
 
-  - type: dropdown
+  - type: input
     id: framework
     attributes:
       label: Target framework
-      options:
-        - net10.0
-        - net472
-        - net48
+      placeholder: "net8.0"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -66,7 +66,7 @@ body:
     attributes:
       label: Target framework
       options:
-        - net8.0
+        - net10.0
         - net472
         - net48
     validations:

--- a/.github/workflows/build-test-pack.yml
+++ b/.github/workflows/build-test-pack.yml
@@ -88,13 +88,13 @@ jobs:
       env:
           MODULE_NAMESPACE: ${{ inputs.module-namespace }}
           MODULE_NAME: ${{ inputs.module-name }}
-    - name: 🧪 test ${{ inputs.module-name }} in net8.0 & collect coverage
+    - name: 🧪 test ${{ inputs.module-name }} in net10.0 & collect coverage
       uses: ./.github/actions/test-and-collect-coverage
       with:
         codecov-token: ${{ secrets.codecov-token }}
         module-name: ${{ inputs.module-name }}
         module-namespace: ${{ inputs.module-namespace }}
-        target-framework: net8.0
+        target-framework: net10.0
     - name: 📦 pack
       if: ${{ startsWith(inputs.module-name, 'Auto' ) }}
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ if it is truly module-specific.
 | Project type | Target frameworks |
 | --- | --- |
 | Library (Core, AutoMoq, etc.) | `netstandard2.0`, `netstandard2.1`, `net472`, `net48` |
-| Tests | `net8.0`, `net472`, `net48` |
+| Tests | `net10.0`, `net472`, `net48` |
 
 ---
 

--- a/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests/Objectivity.AutoFixture.XUnit2.AutoFakeItEasy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests/Objectivity.AutoFixture.XUnit2.AutoMoq.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests/Objectivity.AutoFixture.XUnit2.AutoNSubstitute.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Objectivity.AutoFixture.XUnit2.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)'=='Windows_NT'">$(TargetFrameworks);net472;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
## Summary

- Replaces `net8.0` with `net10.0` in all four test `.csproj` files
- Updates `build-test-pack.yml` workflow to run coverage collection against `net10.0`
- Updates the bug-report issue template framework dropdown
- Updates the `AGENTS.md` Target Frameworks table
- Closes TASK-13 in the backlog

**.NET 8 LTS** ends November 2026; **.NET 10 LTS** is supported until November 2028. No dependency version changes were required — all packages already target `netstandard2.0`/`netstandard2.1`.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 340 passed on `net10.0`, 340 on `net472`, 340 on `net48`

🤖 Generated with [Claude Code](https://claude.com/claude-code)