### PR TITLE
Docs/agents backlog cli reference

### DIFF
--- a/.backlog/tasks/task-15 - Add-backlog-CLI-reference-to-AGENTS.md.md
+++ b/.backlog/tasks/task-15 - Add-backlog-CLI-reference-to-AGENTS.md.md
@@ -1,10 +1,12 @@
 ---
 id: TASK-15
 title: Add backlog CLI reference to AGENTS.md
-status: In Progress
+status: Done
 assignee:
   - claude
+  - piotrzajac
 created_date: '2026-04-17 12:13'
+updated_date: '2026-04-17 12:18'
 labels: []
 dependencies: []
 priority: low
@@ -12,7 +14,6 @@ priority: low
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Backlog CLI Reference section added to AGENTS.md before the MCP guidelines block
-- [ ] #2 Covers task, milestone, search, decision, and doc commands
-- [ ] #3 Section survives future backlog agents --update-instructions runs
+- [x] #1 Backlog CLI Reference section added to AGENTS.md before the MCP guidelines block
+- [x] #2 Section survives future backlog agents --update-instructions runs
 <!-- AC:END -->

--- a/.backlog/tasks/task-15 - Add-backlog-CLI-reference-to-AGENTS.md.md
+++ b/.backlog/tasks/task-15 - Add-backlog-CLI-reference-to-AGENTS.md.md
@@ -1,0 +1,18 @@
+---
+id: TASK-15
+title: Add backlog CLI reference to AGENTS.md
+status: In Progress
+assignee:
+  - claude
+created_date: '2026-04-17 12:13'
+labels: []
+dependencies: []
+priority: low
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Backlog CLI Reference section added to AGENTS.md before the MCP guidelines block
+- [ ] #2 Covers task, milestone, search, decision, and doc commands
+- [ ] #3 Section survives future backlog agents --update-instructions runs
+<!-- AC:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -490,6 +490,28 @@ When proposing any non-trivial solution, evaluate it against these quality dimen
 - **Separation of concerns** — split logic into focused, single-purpose components rather than concentrating multiple responsibilities in one place; each class, method or task should have one clear reason to change
 - **Developer experience** — prefer readable error messages, discoverable APIs, and minimal configuration; the goal of this library is to reduce boilerplate
 
+## Backlog CLI Reference
+
+When MCP is unavailable, use the CLI via `npx backlog` from the repo root.
+Prefer the CLI over editing task files directly — the CLI validates structure.
+
+| Goal | Command |
+| --- | --- |
+| List tasks | `npx backlog task list` |
+| View a task | `npx backlog task show TASK-N` |
+| Create a task | `npx backlog task create "Title" --status "To Do" --priority low` |
+| Update status | `npx backlog task edit TASK-N --status "In Progress"` |
+| Assign | `npx backlog task edit TASK-N --assignee username` |
+| Add acceptance criterion | `npx backlog task edit TASK-N --ac "criterion text"` |
+| Create milestone | `npx backlog milestone create "Name"` |
+| Assign to milestone | `npx backlog task edit TASK-N --milestone m-N` |
+| Search tasks/docs/decisions | `npx backlog search "query" [--status "..."] [--priority ...]` |
+| Record architectural decision | `npx backlog decision create "decision text" [-s proposed\|accepted\|deprecated]` |
+| Create documentation | `npx backlog doc create "Title" [-p path] [-t type]` |
+| List documents | `npx backlog doc list` |
+
+---
+
 <!-- BACKLOG.MD MCP GUIDELINES START -->
 
 <CRITICAL_INSTRUCTION>


### PR DESCRIPTION
# Summary

Add backlog CLI reference for MCP-unavailable environments

<!-- Placeholder in the PR description that CodeRabbit replaces with the high-level summary. -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Backlog CLI Reference section with instructions for using `npx backlog` when needed.
  * Includes a command mapping table for key backlog management operations (tasks, milestones, search, decisions, and documentation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)
- [x] `dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes with no warnings
- [x] `dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes on all framework slices
- [x] Code coverage remains at least at the level prior the change (verified by Codecov)
- [x] Mutation score remains at least at the level prior the change (verified by Stryker)
- [x] New tests follow the GIVEN/WHEN/THEN naming convention and AAA structure (see [AGENTS.md](../AGENTS.md))
- [x] No new `[SuppressMessage]` without a justification comment
- [x] No `// TODO:` comments added — open a GitHub issue instead
- [x] No new dependencies introduced that are incompatible with the MIT license (verified by FOSSA)
