### PR TITLE
fix: resolve CodeQL warnings across Core and test projects

### DIFF
--- a/.backlog/tasks/task-16 - Fix-CodeQL-warnings.md
+++ b/.backlog/tasks/task-16 - Fix-CodeQL-warnings.md
@@ -1,0 +1,24 @@
+---
+id: TASK-16
+title: Fix CodeQL warnings
+status: Done
+assignee:
+  - piotrzajac
+  - claude
+created_date: '2026-04-19 14:23'
+updated_date: '2026-04-19 15:13'
+labels: []
+dependencies: []
+priority: medium
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Collapsible if statements combined (IgnoreVirtualMembersSpecimenBuilder)
+- [x] #2 Default ToString() override added (AbstractTestClass in AutoDataAdapterAttributeTests)
+- [x] #3 Change var to object to resolve incomparable-types Equals warning (ValuesRequestTests)
+- [x] #4 Useless call to GetHashCode() as value is its own hash (ValuesRequestTests)
+- [x] #5 AutoDataAdapterAttribute CustomizeFixture: foreach refactored to use Select projection.
+- [x] #6 CustomizeWithAttributeTests: as+Assert.NotNull replaced with Assert.IsType<T> in Assert section (lines 136, 157)
+- [x] #7 AutoDataAttributeProviderTests: same pattern applied (line 22)
+<!-- AC:END -->

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,3 @@
-# CodeRabbit configuration for AutoFixture.XUnit2.AutoMock
-# https://docs.coderabbit.ai/getting-started/configure-coderabbit
-#
-# One-time prerequisite: install the CodeRabbit GitHub App at the org/repo level.
-# https://github.com/apps/coderabbit-ai
-
 language: "en-US"
 
 reviews:
@@ -16,6 +10,9 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
-
+  pre_merge_checks:
+    docstrings:
+      mode: off
+  
 chat:
   auto_reply: true

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataAdapterAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/AutoDataAdapterAttributeTests.cs
@@ -134,9 +134,9 @@
             return $"{first}: {second}, {third}";
         }
 
-        [SuppressMessage("Minor Code Smell", "S2094:Classes should not be empty", Justification = "Test class")]
         protected abstract class AbstractTestClass
         {
+            public override string ToString() => this.GetType().Name;
         }
 
         protected sealed class SpecificTestClass : AbstractTestClass

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/CustomizeWithAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/CustomizeWithAttributeTests.cs
@@ -130,7 +130,7 @@
                 .First();
 
             // Act
-            var customization = customizeAttribute.GetCustomization(parameter) as ArgumentsDiscoveryCustomization;
+            var customization = customizeAttribute.GetCustomization(parameter);
 
             // Assert
             var typed = Assert.IsType<ArgumentsDiscoveryCustomization>(customization);
@@ -151,7 +151,7 @@
                 .First();
 
             // Act
-            var customization = customizeAttribute.GetCustomization(parameter) as ArgumentsDiscoveryCustomization;
+            var customization = customizeAttribute.GetCustomization(parameter);
 
             // Assert
             var typed = Assert.IsType<ArgumentsDiscoveryCustomization>(customization);

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/CustomizeWithAttributeTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Attributes/CustomizeWithAttributeTests.cs
@@ -133,10 +133,9 @@
             var customization = customizeAttribute.GetCustomization(parameter) as ArgumentsDiscoveryCustomization;
 
             // Assert
-            Assert.NotNull(customization);
-            Assert.IsType(customizationType, customization);
-            Assert.Single(customization.Args);
-            Assert.Equal(parameter.ParameterType, customization.Args.First());
+            var typed = Assert.IsType<ArgumentsDiscoveryCustomization>(customization);
+            Assert.Single(typed.Args);
+            Assert.Equal(parameter.ParameterType, typed.Args.First());
         }
 
         [MemberData(nameof(ArgumentsDiscoveryCustomizationTestData))]
@@ -155,9 +154,8 @@
             var customization = customizeAttribute.GetCustomization(parameter) as ArgumentsDiscoveryCustomization;
 
             // Assert
-            Assert.NotNull(customization);
-            Assert.IsType(customizationType, customization);
-            Assert.Equal(expectedNumberOfArguments, customization.Args.Count);
+            var typed = Assert.IsType<ArgumentsDiscoveryCustomization>(customization);
+            Assert.Equal(expectedNumberOfArguments, typed.Args.Count);
         }
 
         [AutoData]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/AutoDataAttributeProviderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/AutoDataAttributeProviderTests.cs
@@ -22,8 +22,8 @@
             var dataAttribute = provider.GetAttribute(fixture) as AutoDataAdapterAttribute;
 
             // Assert
-            Assert.NotNull(dataAttribute);
-            Assert.Equal(fixture, dataAttribute.AdaptedFixture);
+            var typed = Assert.IsType<AutoDataAdapterAttribute>(dataAttribute);
+            Assert.Equal(fixture, typed.AdaptedFixture);
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/AutoDataAttributeProviderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Providers/AutoDataAttributeProviderTests.cs
@@ -19,7 +19,7 @@
             var provider = new AutoDataAttributeProvider();
 
             // Act
-            var dataAttribute = provider.GetAttribute(fixture) as AutoDataAdapterAttribute;
+            var dataAttribute = provider.GetAttribute(fixture);
 
             // Assert
             var typed = Assert.IsType<AutoDataAdapterAttribute>(dataAttribute);

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
@@ -197,7 +197,7 @@
             // Arrange
             var type = value.GetType();
             var fixedRequest = new FixedValuesRequest(type, value);
-            var exceptRequest = new ExceptValuesRequest(type, value);
+            object exceptRequest = new ExceptValuesRequest(type, value);
 
             // Act
             var result = fixedRequest.Equals(exceptRequest);

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
@@ -174,12 +174,12 @@
         }
 
         [Fact(DisplayName = "GIVEN different type of object WHEN Equals is invoked THEN False is returned")]
-        [SuppressMessage("ReSharper", "SuspiciousTypeConversion.Global", Justification = "This is expected comparioson to test logic.")]
+        [SuppressMessage("ReSharper", "SuspiciousTypeConversion.Global", Justification = "This is expected comparison to test logic.")]
         public void GivenDifferentTypeOfObject_WhenEqualsIsInvoked_ThenFalseIsReturned()
         {
             // Arrange
             var request = new FixedValuesRequest(typeof(int), 1);
-            var differentObject = typeof(int);
+            object differentObject = typeof(int);
 
             // Act
             var result = request.Equals(differentObject);
@@ -190,7 +190,7 @@
 
         [AutoData]
         [Theory(DisplayName = "GIVEN different type of ValuesRequest WHEN Equals is invoked THEN False is returned")]
-        [SuppressMessage("ReSharper", "SuspiciousTypeConversion.Global", Justification = "This is expected comparioson to test logic.")]
+        [SuppressMessage("ReSharper", "SuspiciousTypeConversion.Global", Justification = "This is expected comparison to test logic.")]
         public void GivenDifferentTypeOfValuesRequest_WhenEqualsIsInvoked_ThenFalseIsReturned(
             int value)
         {
@@ -237,7 +237,7 @@
             // Arrange
             var valueType = value.GetType();
             var request = Activator.CreateInstance(requestType, valueType, value);
-            var expectedHashCode = valueType.GetHashCode() ^ requestType.GetHashCode() ^ value.GetHashCode();
+            var expectedHashCode = valueType.GetHashCode() ^ requestType.GetHashCode() ^ value;
 
             // Act
             var actualHashCode = request.GetHashCode();

--- a/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataAdapterAttribute.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/Attributes/AutoDataAdapterAttribute.cs
@@ -48,9 +48,8 @@
                 .OfType<IParameterCustomizationSource>()
                 .OrderBy(x => x, new CustomizeAttributeComparer<FrozenAttribute>());
 
-            foreach (var ca in customizeAttributes)
+            foreach (var c in customizeAttributes.Select(ca => ca.GetCustomization(p)))
             {
-                var c = ca.GetCustomization(p);
                 this.AdaptedFixture.Customize(c);
             }
         }

--- a/src/Objectivity.AutoFixture.XUnit2.Core/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilder.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilder.cs
@@ -20,17 +20,12 @@
 
         public object Create(object request, ISpecimenContext context)
         {
-            if (request is PropertyInfo pi) //// is a property
+            if (request is PropertyInfo pi //// is a property
+                && (this.ReflectedType is null //// is hosted anywhere
+                    || this.ReflectedType == pi.ReflectedType) //// is hosted in defined type
+                && pi.GetGetMethod().IsVirtual)
             {
-                if (this.ReflectedType is null //// is hosted anywhere
-                    ||
-                    this.ReflectedType == pi.ReflectedType) //// is hosted in defined type
-                {
-                    if (pi.GetGetMethod().IsVirtual)
-                    {
-                        return new OmitSpecimen();
-                    }
-                }
+                return new OmitSpecimen();
             }
 
             return new NoSpecimen();


### PR DESCRIPTION
## Summary
- Combine nested `if` statements in `IgnoreVirtualMembersSpecimenBuilder`
- Add `ToString()` override to `AbstractTestClass` to fix default `Object.ToString()` warning
- Use `object` instead of `var` in `ValuesRequestTests` to resolve incomparable-types `Equals` warning
- Remove redundant `GetHashCode()` call on `int` in `ValuesRequestTests`
- Refactor `CustomizeFixture` `foreach` to use `.Select()` projection in `AutoDataAdapterAttribute`
- Replace `as` + `Assert.NotNull` with `Assert.IsType<T>` in Assert section in `CustomizeWithAttributeTests` and `AutoDataAttributeProviderTests`

<!-- Placeholder in the PR description that CodeRabbit replaces with the high-level summary. -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multiple CodeQL static analysis warnings across test suites and core components to enhance code safety, reliability, and overall quality standards.

* **Chores**
  * Added detailed backlog task documentation for comprehensive CodeQL warning remediation tracking.
  * Enhanced test assertion patterns and refactored conditional logic for improved code maintainability, clarity, and consistency throughout the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Test plan
- [x] Build passes with 0 warnings and 0 errors
- [x] All tests pass across all framework slices (net10.0, net472, net48)

🤖 Generated with [Claude Code](https://claude.com/claude-code)