### PR TITLE
fix(codeql): Fix CodeQL issues

### DIFF
--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
@@ -88,8 +88,8 @@
             Assert.Equal(values, attribute.Values);
         }
 
-        [Fact(DisplayName = "GIVEN valid arguments WHEN ToString is invoked THEN text conteins necessary information")]
-        public void GivenValidArguments_WhenToStringIsInvoked_ThenTextConteinsNecessaryInformation()
+        [Fact(DisplayName = "GIVEN valid arguments WHEN ToString is invoked THEN text contains necessary information")]
+        public void GivenValidArguments_WhenToStringIsInvoked_ThenTextContainsNecessaryInformation()
         {
             // Arrange
             var type = typeof(float);

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilderTests.cs
@@ -77,6 +77,7 @@
             var specimen = builder.Create(notVirtualPropertyInfo, this.context);
 
             // Assert
+            Assert.NotNull(notVirtualPropertyInfo.GetGetMethod());
             Assert.IsType<NoSpecimen>(specimen);
         }
 
@@ -93,6 +94,7 @@
             var specimen = builder.Create(virtualPropertyInfo, this.context);
 
             // Assert
+            Assert.NotNull(virtualPropertyInfo.GetGetMethod());
             Assert.Same(reflectedType, builder.ReflectedType);
             Assert.IsType<NoSpecimen>(specimen);
         }
@@ -109,6 +111,7 @@
             var specimen = builder.Create(virtualPropertyInfo, this.context);
 
             // Assert
+            Assert.NotNull(virtualPropertyInfo.GetGetMethod());
             Assert.IsType<OmitSpecimen>(specimen);
         }
 
@@ -124,6 +127,7 @@
             var specimen = builder.Create(propertyInfo, this.context);
 
             // Assert
+            Assert.Null(propertyInfo.GetGetMethod());
             Assert.IsType<NoSpecimen>(specimen);
         }
 
@@ -139,6 +143,7 @@
             var specimen = builder.Create(virtualPropertyInfo, this.context);
 
             // Assert
+            Assert.NotNull(virtualPropertyInfo.GetGetMethod());
             Assert.IsType<OmitSpecimen>(specimen);
         }
 
@@ -150,7 +155,7 @@
 
             public virtual object VirtualProperty { get; set; }
 
-            [SuppressMessage("Design", "CA1044:Properties should not be write only", Justification = "Required to test null getter scenario.")]
+            [SuppressMessage("Design", "CA1044:Properties should not be write only", Justification = "Required to test that GetGetMethod() returns null when getter is non-public.")]
             public virtual object VirtualPropertyWithPrivateGetter { private get; set; }
         }
     }

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilderTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilderTests.cs
@@ -112,6 +112,21 @@
             Assert.IsType<OmitSpecimen>(specimen);
         }
 
+        [AutoData]
+        [Theory(DisplayName = "GIVEN virtual PropertyInfo with private getter WHEN Create is invoked THEN NoSpecimen is returned")]
+        public void GivenVirtualPropertyInfoWithPrivateGetter_WhenCreateInvoked_ThenNoSpecimenInstance(
+            [Modest] IgnoreVirtualMembersSpecimenBuilder builder)
+        {
+            // Arrange
+            var propertyInfo = typeof(FakeObject).GetProperty(nameof(FakeObject.VirtualPropertyWithPrivateGetter));
+
+            // Act
+            var specimen = builder.Create(propertyInfo, this.context);
+
+            // Assert
+            Assert.IsType<NoSpecimen>(specimen);
+        }
+
         [Fact(DisplayName = "GIVEN virtual PropertyInfo request hosted in appropriate type WHEN Create is invoked THEN OmitSpecimen is returned")]
         public void GivenVirtualPropertyInfoRequestHostedInAppropriateType_WhenCreateInvoked_ThenOmitSpecimenInstance()
         {
@@ -134,6 +149,9 @@
             public object NotVirtualProperty { get; set; }
 
             public virtual object VirtualProperty { get; set; }
+
+            [SuppressMessage("Design", "CA1044:Properties should not be write only", Justification = "Required to test null getter scenario.")]
+            public virtual object VirtualPropertyWithPrivateGetter { private get; set; }
         }
     }
 }

--- a/src/Objectivity.AutoFixture.XUnit2.Core/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilder.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilder.cs
@@ -23,7 +23,7 @@
             if (request is PropertyInfo pi //// is a property
                 && (this.ReflectedType is null //// is hosted anywhere
                     || this.ReflectedType == pi.ReflectedType) //// is hosted in defined type
-                && pi.GetGetMethod().IsVirtual)
+                && pi.GetGetMethod() is { IsVirtual: true })
             {
                 return new OmitSpecimen();
             }


### PR DESCRIPTION
# Summary

Fix CodeQL issues:
- Spelling
- Handle private getters in `IgnoreVirtualMembersSpecimenBuilder`

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)
- [x] `dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes with no warnings
- [x] `dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes on all framework slices
- [x] Code coverage remains at least at the level prior the change (verified by Codecov)
- [x] Mutation score remains at least at the level prior the change (verified by Stryker)
- [x] New tests follow the GIVEN/WHEN/THEN naming convention and AAA structure (see [AGENTS.md](../AGENTS.md))
- [x] No new `[SuppressMessage]` without a justification comment
- [x] No `// TODO:` comments added — open a GitHub issue instead
- [x] No new dependencies introduced that are incompatible with the MIT license (verified by FOSSA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for virtual properties with private getters.
  * Corrected spelling in test naming for consistency.

* **Bug Fixes**
  * Improved virtual member detection logic to handle null cases more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->