### PR TITLE
fix: virtual member check in IgnoreVirtualMembersSpecimenBuilder

### DIFF
--- a/src/Objectivity.AutoFixture.XUnit2.Core/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilder.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core/SpecimenBuilders/IgnoreVirtualMembersSpecimenBuilder.cs
@@ -23,7 +23,7 @@
             if (request is PropertyInfo pi //// is a property
                 && (this.ReflectedType is null //// is hosted anywhere
                     || this.ReflectedType == pi.ReflectedType) //// is hosted in defined type
-                && pi.GetGetMethod(nonPublic: false) is { IsVirtual: true })
+                && pi.GetGetMethod() is { IsVirtual: true })
             {
                 return new OmitSpecimen();
             }


### PR DESCRIPTION
# Summary

<!-- Placeholder in the PR description that CodeRabbit replaces with the high-level summary. -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual member detection in specimen generation to properly identify virtual properties regardless of getter accessibility levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)
- [x] `dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes with no warnings
- [x] `dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes on all framework slices
- [x] Code coverage remains at least at the level prior the change (verified by Codecov)
- [x] Mutation score remains at least at the level prior the change (verified by Stryker)
- [x] New tests follow the GIVEN/WHEN/THEN naming convention and AAA structure (see [AGENTS.md](../AGENTS.md))
- [x] No new `[SuppressMessage]` without a justification comment
- [x] No `// TODO:` comments added — open a GitHub issue instead
- [x] No new dependencies introduced that are incompatible with the MIT license (verified by FOSSA)
