### PR TITLE
refactor(tests): consolidate duplicate Facts into Theories

### DIFF
--- a/.backlog/tasks/task-17 - Consolidate-duplicate-Facts-into-Theories.md
+++ b/.backlog/tasks/task-17 - Consolidate-duplicate-Facts-into-Theories.md
@@ -14,6 +14,6 @@ priority: low
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] #1 Identify all [Fact] methods across the all test projects that test the same behavior with different inputs
+- [x] #1 Identify all [Fact] methods across all test projects that test the same behavior with different inputs
 - [x] #2 Replace duplicate Facts with a single [Theory] using [InlineData] or [MemberData]/[TheoryData] as appropriate
 <!-- AC:END -->

--- a/.backlog/tasks/task-17 - Consolidate-duplicate-Facts-into-Theories.md
+++ b/.backlog/tasks/task-17 - Consolidate-duplicate-Facts-into-Theories.md
@@ -1,0 +1,19 @@
+---
+id: TASK-17
+title: Consolidate duplicate Facts into Theories
+status: Done
+assignee:
+  - claude
+  - piotrzajac
+created_date: '2026-04-21 08:21'
+updated_date: '2026-04-21 11:06'
+labels: []
+dependencies: []
+priority: low
+---
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Identify all [Fact] methods across the all test projects that test the same behavior with different inputs
+- [x] #2 Replace duplicate Facts with a single [Theory] using [InlineData] or [MemberData]/[TheoryData] as appropriate
+<!-- AC:END -->

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": true
     },
     "dotnet-stryker": {
-      "version": "4.14.0",
+      "version": "4.14.1",
       "commands": [
         "dotnet-stryker"
       ],

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Common/EnumerableExtensionsTests.cs
@@ -15,6 +15,13 @@
     [Trait("Category", "Common")]
     public class EnumerableExtensionsTests
     {
+        public static TheoryData<Type> InvalidCollectionTestData { get; } = new()
+        {
+            typeof(Tuple<int, int>),
+            typeof(IEnumerable),
+            typeof(IEnumerable<int>).GetGenericTypeDefinition(),
+        };
+
         [Fact(DisplayName = "GIVEN uninitialized argument WHEN TryGetEnumerableSingleTypeArgument is invoked THEN exception is thrown")]
         [SuppressMessage("ReSharper", "UnusedVariable", Justification = "This is good enougth to test the logic.")]
         public void GivenUninitializedArgument_WhenTryGetEnumerableSingleTypeArgumentIsInvoked_ThenExceptionIsThrown()
@@ -46,25 +53,11 @@
             Assert.Equal(expectedType, itemType);
         }
 
-        [InlineData(typeof(Tuple<int, int>))]
-        [InlineData(typeof(IEnumerable))]
+        [MemberData(nameof(InvalidCollectionTestData))]
         [Theory(DisplayName = "GIVEN invalid collection WHEN TryGetEnumerableSingleTypeArgument is invoked THEN no argument returned")]
         public void GivenInvalidCollection_WhenTryGetEnumerableSingleTypeArgumentIsInvoked_ThenNoArgumentReturned(Type enumerableType)
         {
             // Arrange
-            // Act
-            var isSuccessful = enumerableType.TryGetEnumerableSingleTypeArgument(out _);
-
-            // Assert
-            Assert.False(isSuccessful);
-        }
-
-        [Fact(DisplayName = "GIVEN generic definition collection WHEN TryGetEnumerableSingleTypeArgument is invoked THEN no argument returned")]
-        public void GivenGenericDefinitionCollection_WhenTryGetEnumerableSingleTypeArgumentIsInvoked_ThenNoArgumentReturned()
-        {
-            // Arrange
-            var enumerableType = typeof(IEnumerable<int>).GetGenericTypeDefinition();
-
             // Act
             var isSuccessful = enumerableType.TryGetEnumerableSingleTypeArgument(out _);
 

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
@@ -16,7 +16,7 @@
     {
         public static TheoryData<Type, object[], string> NullArgumentConstructorTestData { get; } = new()
         {
-            { null, null, "operandType" },
+            { null, new object[] { 1 }, "operandType" },
             { typeof(int), null, "values" },
         };
 

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/Requests/ValuesRequestTests.cs
@@ -14,6 +14,12 @@
     [Trait("Category", "Requests")]
     public class ValuesRequestTests
     {
+        public static TheoryData<Type, object[], string> NullArgumentConstructorTestData { get; } = new()
+        {
+            { null, null, "operandType" },
+            { typeof(int), null, "values" },
+        };
+
         public static TheoryData<Type, IEnumerable, Type, IEnumerable, bool> ComparisonTestData { get; } = new()
         {
             { typeof(int), new[] { 1 }, typeof(int), new[] { 1 }, true },
@@ -24,34 +30,18 @@
             { typeof(int), new[] { 1, 2 }, typeof(int), new[] { 2 }, false },
         };
 
-        [Fact(DisplayName = "GIVEN uninitialized type argument WHEN constructor is invoked THEN exception is thrown")]
-        public void GivenUninitializedTypeArgument_WhenConstructorIsInvoked_ThenExceptionIsThrown()
+        [MemberData(nameof(NullArgumentConstructorTestData))]
+        [Theory(DisplayName = "GIVEN uninitialized argument WHEN constructor is invoked THEN exception is thrown")]
+        public void GivenUninitializedArgument_WhenConstructorIsInvoked_ThenExceptionIsThrown(
+            Type type, object[] values, string expectedParamName)
         {
             // Arrange
-            Type type = null;
-            object[] values = null;
-
             // Act
             object Act() => new FixedValuesRequest(type, values);
 
             // Assert
             var exception = Assert.Throws<ArgumentNullException>(Act);
-            Assert.Equal("operandType", exception.ParamName);
-        }
-
-        [Fact(DisplayName = "GIVEN uninitialized values argument WHEN constructor is invoked THEN exception is thrown")]
-        public void GivenUninitializedValuesArgument_WhenConstructorIsInvoked_ThenExceptionIsThrown()
-        {
-            // Arrange
-            var type = typeof(int);
-            object[] values = null;
-
-            // Act
-            object Act() => new FixedValuesRequest(type, values);
-
-            // Assert
-            var exception = Assert.Throws<ArgumentNullException>(Act);
-            Assert.Equal("values", exception.ParamName);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN empty values argument WHEN constructor is invoked THEN exception is thrown")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RandomExceptValuesGeneratorTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RandomExceptValuesGeneratorTests.cs
@@ -16,33 +16,25 @@
     [Trait("Category", "SpecimenBuilders")]
     public class RandomExceptValuesGeneratorTests
     {
-        [Fact(DisplayName = "GIVEN uninitialized context WHEN Create is invoked THEN exception is thrown")]
-        public void GivenUninitializedContext_WhenCreateIsInvoked_ThenExceptionIsThrown()
+        public static TheoryData<object, ISpecimenContext, string> NullArgumentCreateTestData { get; } = new()
+        {
+            { new object(), null, "context" },
+            { null, new Mock<ISpecimenContext>().Object, "request" },
+        };
+
+        [MemberData(nameof(NullArgumentCreateTestData))]
+        [Theory(DisplayName = "GIVEN uninitialized argument WHEN Create is invoked THEN exception is thrown")]
+        public void GivenUninitializedArgument_WhenCreateIsInvoked_ThenExceptionIsThrown(object request, ISpecimenContext context, string expectedParamName)
         {
             // Arrange
             var builder = new RandomExceptValuesGenerator();
 
             // Act
-            object Act() => builder.Create(new object(), null);
+            object Act() => builder.Create(request, context);
 
             // Assert
             var exception = Assert.Throws<ArgumentNullException>(Act);
-            Assert.Equal("context", exception.ParamName);
-        }
-
-        [Fact(DisplayName = "GIVEN uninitialized request WHEN Create is invoked THEN exception is thrown")]
-        public void GivenUninitializedRequest_WhenCreateIsInvoked_ThenExceptionIsThrown()
-        {
-            // Arrange
-            var builder = new RandomExceptValuesGenerator();
-            var context = new Mock<ISpecimenContext>();
-
-            // Act
-            object Act() => builder.Create(null, context.Object);
-
-            // Assert
-            var exception = Assert.Throws<ArgumentNullException>(Act);
-            Assert.Equal("request", exception.ParamName);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN excluded value and context which resolves to the same value WHEN Create is invoked THEN exception is thrown")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RandomFixedValuesGeneratorTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RandomFixedValuesGeneratorTests.cs
@@ -17,33 +17,25 @@
     [Trait("Category", "SpecimenBuilders")]
     public class RandomFixedValuesGeneratorTests
     {
-        [Fact(DisplayName = "GIVEN uninitialized context WHEN Create is invoked THEN exception is thrown")]
-        public void GivenUninitializedContext_WhenCreateIsInvoked_ThenExceptionIsThrown()
+        public static TheoryData<object, ISpecimenContext, string> NullArgumentCreateTestData { get; } = new()
+        {
+            { new object(), null, "context" },
+            { null, new Mock<ISpecimenContext>().Object, "request" },
+        };
+
+        [MemberData(nameof(NullArgumentCreateTestData))]
+        [Theory(DisplayName = "GIVEN uninitialized argument WHEN Create is invoked THEN exception is thrown")]
+        public void GivenUninitializedArgument_WhenCreateIsInvoked_ThenExceptionIsThrown(object request, ISpecimenContext context, string expectedParamName)
         {
             // Arrange
             var builder = new RandomFixedValuesGenerator();
 
             // Act
-            object Act() => builder.Create(new object(), null);
+            object Act() => builder.Create(request, context);
 
             // Assert
             var exception = Assert.Throws<ArgumentNullException>(Act);
-            Assert.Equal("context", exception.ParamName);
-        }
-
-        [Fact(DisplayName = "GIVEN uninitialized request WHEN Create is invoked THEN exception is thrown")]
-        public void GivenUninitializedRequest_WhenCreateIsInvoked_ThenExceptionIsThrown()
-        {
-            // Arrange
-            var builder = new RandomFixedValuesGenerator();
-            var context = new Mock<ISpecimenContext>();
-
-            // Act
-            object Act() => builder.Create(null, context.Object);
-
-            // Assert
-            var exception = Assert.Throws<ArgumentNullException>(Act);
-            Assert.Equal("request", exception.ParamName);
+            Assert.Equal(expectedParamName, exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN unsupported request WHEN Create is invoked THEN NoSpecimen is returned")]

--- a/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RequestFactoryRelayTests.cs
+++ b/src/Objectivity.AutoFixture.XUnit2.Core.Tests/SpecimenBuilders/RequestFactoryRelayTests.cs
@@ -21,6 +21,12 @@
     [Trait("Category", "SpecimenBuilders")]
     public class RequestFactoryRelayTests
     {
+        public static TheoryData<object, ISpecimenContext, string> NullArgumentCreateTestData { get; } = new()
+        {
+            { new object(), null, "context" },
+            { null, new Mock<ISpecimenContext>().Object, "request" },
+        };
+
         [Fact(DisplayName = "GIVEN uninitialized argument WHEN constructor is invoked THEN exception is thrown")]
         public void GivenUninitializedArgument_WhenConstructorIsInvoked_ThenExceptionIsThrown()
         {
@@ -33,36 +39,21 @@
             Assert.Equal("requestFactory", exception.ParamName);
         }
 
-        [Fact(DisplayName = "GIVEN empty argument WHEN Create is invoked THEN exception is thrown")]
-        public void GivenEmptyArgument_WhenCreateIsInvoked_ThenExceptionIsThrown()
+        [MemberData(nameof(NullArgumentCreateTestData))]
+        [Theory(DisplayName = "GIVEN uninitialized argument WHEN Create is invoked THEN exception is thrown")]
+        public void GivenUninitializedArgument_WhenCreateIsInvoked_ThenExceptionIsThrown(object request, ISpecimenContext context, string expectedParamName)
         {
             // Arrange
             var factory = new Mock<Func<Type, object>>();
             var builder = new RequestFactoryRelay(factory.Object);
 
             // Act
-            object Act() => builder.Create(new object(), null);
+            object Act() => builder.Create(request, context);
 
             // Assert
             var exception = Assert.Throws<ArgumentNullException>(Act);
-            Assert.Equal("context", exception.ParamName);
+            Assert.Equal(expectedParamName, exception.ParamName);
             factory.VerifyNoOtherCalls();
-        }
-
-        [Fact(DisplayName = "GIVEN uninitialized request WHEN Create is invoked THEN exception is thrown")]
-        public void GivenUninitializedRequest_WhenCreateIsInvoked_ThenExceptionIsThrown()
-        {
-            // Arrange
-            var factory = new Mock<Func<Type, object>>();
-            var builder = new RequestFactoryRelay(factory.Object);
-            var context = new Mock<ISpecimenContext>();
-
-            // Act
-            object Act() => builder.Create(null, context.Object);
-
-            // Assert
-            var exception = Assert.Throws<ArgumentNullException>(Act);
-            Assert.Equal("request", exception.ParamName);
         }
 
         [Fact(DisplayName = "GIVEN unsupported request type WHEN create is invoked THEN NoSpecimen is returned")]


### PR DESCRIPTION
# Summary

Replace pairs of [Fact] methods that tested the same behaviour with different inputs with a single [Theory] using [InlineData] or [MemberData]/[TheoryData].

<!-- Placeholder in the PR description that CodeRabbit replaces with the high-level summary. -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dotnet-stryker tool to version 4.14.1

* **Tests**
  * Consolidated duplicate test cases into parameterized tests for improved maintainability
  * Added new backlog task documenting test consolidation objectives
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`)
- [x] `dotnet build src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes with no warnings
- [x] `dotnet test src/Objectivity.AutoFixture.XUnit2.AutoMock.sln` passes on all framework slices
- [x] Code coverage remains at least at the level prior the change (verified by Codecov)
- [x] Mutation score remains at least at the level prior the change (verified by Stryker)
- [x] New tests follow the GIVEN/WHEN/THEN naming convention and AAA structure (see [AGENTS.md](../AGENTS.md))
- [x] No new `[SuppressMessage]` without a justification comment
- [x] No `// TODO:` comments added — open a GitHub issue instead
- [x] No new dependencies introduced that are incompatible with the MIT license (verified by FOSSA)
